### PR TITLE
Fix docs: cross references to sections in different files

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -195,6 +195,8 @@ theme, use the condition grouping syntax::
         <copy css:content="h2.articleheading" css:theme="h1"/>
     </rules>
 
+.. _modifying-the-theme-on-the-fly:
+
 Modifying the theme on the fly
 ------------------------------
 
@@ -243,6 +245,8 @@ Inline markup and XSLT may be combined with conditions::
     <before css:theme"#content-wrapper" css:if-content="body.blog-page">
         <div class="notice">Welcome to our new blog</div>
     </before>
+
+.. _modifying-the-content-on-the-fly:
 
 Modifying the content on the fly
 --------------------------------

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -155,8 +155,9 @@ The following attributes are allowed:
     Used to specify an element that must be present in the content for the
     replacement to be performed.
 
-For more advanced usage of ``<replace>``, see `Modifying the theme on the
-fly`_ and `Modifying the content on the fly`_.
+For more advanced usage of ``<replace>``, 
+see :ref:`modifying-the-theme-on-the-fly`
+and :ref:`modifying-the-content-on-the-fly`.
 
 ``<before />`` and ``<after />``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixing broken links in docs basic.html
to sections "Modifying the theme on the fly" and "Modifying the content on the fly".

Actually I did search for other such wrong references and found just those 2

see http://sphinx.pocoo.org/markup/inline.html#cross-referencing-arbitrary-locations
