### PR TITLE
Updated docs contributing section to reflect the usual github fork / pull request workflow

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,4 +1,6 @@
-Contributing to this documentation 
+.. _contributing-to-this-documentation:
+
+Contributing to this documentation
 ==================================
 
 Contributing to this documentation is easy, just follow these steps*:
@@ -7,29 +9,39 @@ Contributing to this documentation is easy, just follow these steps*:
 
 .. _Sphinx: http://pypi.python.org/pypi/Sphinx
 
-2. Check out the documentation::
+2. Fork the github repository at https://github.com/plone/diazo.
 
-    $ git clone https://github.com/plone/diazo diazo
+   If you don't know how to do it, check `Fork a Repo <http://help.github.com/fork-a-repo/>`_
+   at GitHub Help.
 
-3. Change directories to the documentation directory::
+3. Check out the repository you just forked::
+
+    $ git clone https://github.com/YOUR-GITHUB-USERNAME/diazo
+
+4. Change directories to the documentation directory::
 
     $ cd diazo/docs
 
-4. Make your changes. If you don't know Sphinx or reStructuredText, 
+5. Make your changes. If you don't know Sphinx or reStructuredText, 
    you can read about them respectively here_, `and here`_.
+
+   To see the final result you can run::
+
+    $ make html
 
 .. _here: http://sphinx.pocoo.org/
 .. _`and here`: http://docutils.sourceforge.net/rst.html
 
-
-5. Commit your changes::
+6. Commit your changes and push them back to your github fork::
 
     $ git commit -m 'Added documentation to make the world a better place'
+    $ git push origin master
 
+7. Send a `pull request <http://help.github.com/send-pull-requests/>`_
+   with your changes.
 
-(*) You will need core contributor access, you can read about that here:
-
-    - http://dev.plone.org/plone/
+   See how in `Send Pull Requests <http://help.github.com/send-pull-requests/>`_
+   at GitHub Help.
 
 
 Contributing to Diazo
@@ -38,10 +50,11 @@ Contributing to Diazo
 Diazo is maintained by the Plone project. The canonical source code
 repository can be found at::
 
-    https://svn.plone.org/svn/plone/diazo/
+    https://github.com/plone/diazo
     
-Note that commit rights require a signed Plone contributor agreement. Patches
-are received with thanks.
+You can follow the same 
+:ref:`fork & pull request <contributing-to-this-documentation>`
+procedure described above to contribute to the source.
 
 Discussion about the development of Diazo happens mainly on the
 ``plone-developers`` mailing list.
@@ -50,8 +63,9 @@ If you have questions as a user of Diazo, please see http://plone.org/support.
 
 Some important ground rules:
 
-* Please do all new features on a branch and ask for review before
-  merging.
+* Please do each new features on a separate branch.
+  Bugfixes can be done in the *master* branch.
+
 * Keep the tests passing and write new tests (simply create a new directory
   in the ``tests/`` directory following the convention of the existing
   tests).


### PR DESCRIPTION
Please verify if the updated docs section really makes sense and adjust where needed.

I based the rewriting in the usual GitHub workflow for contributions.

Note that I removed the mentions to the "core contributor " way.
I understand that those who already are core contributors do not need a "how to" section for this at all.
Please check if that applies.
