### PR TITLE
Add support for tox (http://tox.testrun.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 *.pyc
 *.pyo
 *.egg-info
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27
+
+[testenv]
+changedir = {envdir}
+commands =
+    cp -pr {toxinidir}/bootstrap.py {toxinidir}/setup.py {toxinidir}/README.txt {toxinidir}/buildout.cfg {toxinidir}/docs {toxinidir}/lib {envdir}
+    {envpython} bootstrap.py
+    {envbindir}/buildout -t 5 -Nq
+    {envbindir}/test


### PR DESCRIPTION
[Tox](http://tox.testrun.org) lets you test against multiple versions of Python. This is similar to what Travis CI does, but the benefit of tox is that you run it on your working directory so you can test code BEFORE you check it in and inflict it on others. :-)
