### PR TITLE
Add the ability to specify XSLT filename by path relative to any given available egg

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -49,10 +49,13 @@ The following options can be passed to ``XSLTMiddleware``:
 
 ``filename``
     A filename from which to read the XSLT file
+``egg_resource``
+    A egg resource specification in the form ``egg_name:path/to/file`` from
+    which to read the XSLT file
 ``tree``
     A pre-parsed lxml tree representing the XSLT file
 
-``filename`` and ``tree`` are mutually exclusive. One is required.
+``filename``, ``egg_resource`` and ``tree`` are mutually exclusive. One is required.
 
 ``read_network``
     Set this to True to allow resolving resources from the network. Defaults

--- a/lib/diazo/tests/test_wsgi.py
+++ b/lib/diazo/tests/test_wsgi.py
@@ -134,7 +134,7 @@ XSLT_PARAM = """\
 """
 
 class TestXSLTMiddleware(unittest.TestCase):
-    
+
     def test_transform_filename(self):
         import tempfile
         import os
@@ -154,6 +154,25 @@ class TestXSLTMiddleware(unittest.TestCase):
         
         app = XSLTMiddleware(application, {}, filename=filename)
         os.unlink(filename)
+        
+        request = Request.blank('/')
+        response = request.get_response(app)
+        
+        self.assertEqual(response.headers['Content-Type'], 'text/html; charset=UTF-8')
+        self.assertTrue('<div id="content">Content content</div>' in response.body)
+        self.assertTrue('<title>Transformed</title>' in response.body)
+    
+    def test_transform_egg_resource(self):
+        from diazo.wsgi import XSLTMiddleware
+        from webob import Request
+        
+        def application(environ, start_response):
+            status = '200 OK'
+            response_headers = [('Content-Type', 'text/html')]
+            start_response(status, response_headers)
+            return [HTML]
+        
+        app = XSLTMiddleware(application, {}, egg_resource="diazo:tests/test_wsgi_files/egg_resource_test_file.xml")
         
         request = Request.blank('/')
         response = request.get_response(app)

--- a/lib/diazo/tests/test_wsgi_files/egg_resource_test_file.xml
+++ b/lib/diazo/tests/test_wsgi_files/egg_resource_test_file.xml
@@ -1,0 +1,16 @@
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    version="1.0"
+    exclude-result-prefixes="xhtml">
+    <xsl:template match="/">
+    <html>
+        <head>
+            <title>Transformed</title>
+        </head>
+        <body>
+            <xsl:copy-of select="//div[@id='content']" />
+        </body>
+    </html>
+    </xsl:template>
+</xsl:stylesheet>

--- a/lib/diazo/wsgi.py
+++ b/lib/diazo/wsgi.py
@@ -109,7 +109,7 @@ class XSLTMiddleware(object):
     """
     
     def __init__(self, app, global_conf,
-                 filename=None, tree=None,
+                 filename=None, egg_resource=None, tree=None,
                  read_network=False,
                  read_file=True,
                  update_content_length=False,
@@ -132,9 +132,11 @@ class XSLTMiddleware(object):
         The parameters are:
         
         * ``filename``, a filename from which to read the XSLT file
+        * ``egg_resource``, a egg resource specification in the form
+          ``egg_name:path/to/file`` from which to read the XSLT file
         * ``tree``, a pre-parsed lxml tree representing the XSLT file
         
-        ``filename`` and ``tree`` are mutually exclusive.
+        ``filename``, ``egg_resource`` and ``tree`` are mutually exclusive.
         
         * ``read_network``, should be set to True to allow resolving resources
           from the network.
@@ -167,6 +169,9 @@ class XSLTMiddleware(object):
         self.app = app
         self.global_conf = global_conf
         
+        if egg_resource is not None:
+            filename = pkg_resources.resource_filename(*egg_resource.split(':'))
+
         if filename is not None:
             xslt_file = open(filename)
             source = xslt_file.read()


### PR DESCRIPTION
As an alternative to specifying `filename` or `tree` in your WSGI configuration, one may specify an egg resource in the form:

`egg_name:path/to/resource`
