### PR TITLE
Allow Diazo and XSLT middleware to read headers to select theme

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,9 +4,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-* Allow Diazo middleware to read rules file location from HTTP headers.
-  This requires explicitly specifying ``read_headers`` as an option against
-  the middleware.
+* Allow Diazo and XSLT middleware to read rules file location from HTTP
+  headers. This requires explicitly specifying ``read_headers`` as an option
+  against the middleware.
   [davidjb]
 * Allow attributes (i.e. xml:id) to pass through on drop @attribute nodes
   [lentinj]

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -52,8 +52,17 @@ The following options can be passed to ``XSLTMiddleware``:
 ``tree``
     A pre-parsed lxml tree representing the XSLT file
 
-``filename`` and ``tree`` are mutually exclusive. One is required.
+``filename`` and ``tree`` are mutually exclusive. One is required, except in
+the situation when ``read_headers`` is enabled and the XSL location is being
+sent from another part of the pipeline. In this special case, the transform is
+loaded as late as possible after obtaining a WSGI response and after taking
+into account potential situations where transformation should not take place.
 
+``read_headers``
+    Set this to True to allow resolving options from HTTP
+    headers. At present, ``X-XLST-Stylesheet`` is the only such option, which
+    refers to the file path to an XSL file.  *Warning*: beware of enabling 
+    this option if users are able to spoof headers.
 ``read_network``
     Set this to True to allow resolving resources from the network. Defaults
     to False.

--- a/lib/diazo/tests/test_wsgi_files/simple_transform.xsl
+++ b/lib/diazo/tests/test_wsgi_files/simple_transform.xsl
@@ -1,0 +1,16 @@
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    version="1.0"
+    exclude-result-prefixes="xhtml">
+    <xsl:template match="/">
+    <html>
+        <head>
+            <title>Transformed</title>
+        </head>
+        <body>
+            <xsl:copy-of select="//div[@id='content']" />
+        </body>
+    </html>
+    </xsl:template>
+</xsl:stylesheet>

--- a/lib/diazo/tests/test_wsgi_files/simple_transform_response.xsl
+++ b/lib/diazo/tests/test_wsgi_files/simple_transform_response.xsl
@@ -1,0 +1,16 @@
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    version="1.0"
+    exclude-result-prefixes="xhtml">
+    <xsl:template match="/">
+    <html>
+        <head>
+            <title>Used response header</title>
+        </head>
+        <body>
+            <xsl:copy-of select="//div[@id='content']" />
+        </body>
+    </html>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Effectively, allowing the middleware to use HTTP headers to select their rules/XSLT would mean being able to have one (or several) Diazo-middleware workers that don't require concrete configuration to theme -- one need only set the headers and an appropriate theme will be used.

In my specific case, this would mean my web server can control the theme being sent (eg for a certain sub-directory, regex match or any other condition my front end supports) by adjusting the header being sent back to the middleware. 

Tests and docs included.
