### PR TITLE
Fix multiple xml:lang attributes error

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,15 +4,15 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+* Remove any xml:lang attribute from content to prevent multiple
+  xml:lang attributes when the html tag's attributes are copied.
+  [danjacka]
 
 1.0.5 (2014-01-27)
 ------------------
 
-- Escape curly brackets on theme attributes.
+* Escape curly brackets on theme attributes.
   [TracyWebTech]
-
 
 1.0.4 (2013-08-14)
 ------------------

--- a/lib/diazo/defaults.xsl
+++ b/lib/diazo/defaults.xsl
@@ -33,7 +33,7 @@
         <xsl:value-of select="str:replace(., '&#13;&#10;', '&#10;')" disable-output-escaping="yes"/>
     </xsl:template>
 
-    <xsl:template match="/html/@xmlns">
+    <xsl:template match="/html/@xmlns|/html/@*[local-name()='xml:lang']">
         <!-- Filter out -->
     </xsl:template>
 

--- a/lib/diazo/filter_html.xsl
+++ b/lib/diazo/filter_html.xsl
@@ -34,7 +34,7 @@
         <xsl:value-of select="str:replace(., '&#13;&#10;', '&#10;')" disable-output-escaping="yes"/>
     </xsl:template>
 
-    <xsl:template match="/html/@xmlns">
+    <xsl:template match="/html/@xmlns|/html/@*[local-name()='xml:lang']">
         <!-- Filter out -->
     </xsl:template>
 

--- a/lib/diazo/filter_xhtml.xsl
+++ b/lib/diazo/filter_xhtml.xsl
@@ -36,7 +36,7 @@
         <xsl:value-of select="str:replace(., '&#13;&#10;', '&#10;')" disable-output-escaping="yes"/>
     </xsl:template>
 
-    <xsl:template match="/html/@xmlns">
+    <xsl:template match="/html/@xmlns|/html/@*[local-name()='xml:lang']">
         <!-- Filter out -->
     </xsl:template>
 

--- a/lib/diazo/tests/html-xml-lang-3/content.html
+++ b/lib/diazo/tests/html-xml-lang-3/content.html
@@ -1,0 +1,1 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"></html>

--- a/lib/diazo/tests/html-xml-lang-3/output.html
+++ b/lib/diazo/tests/html-xml-lang-3/output.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body>
+    Check that xml:lang is not output twice
+  </body>
+</html>

--- a/lib/diazo/tests/html-xml-lang-3/rules.xml
+++ b/lib/diazo/tests/html-xml-lang-3/rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://namespaces.plone.org/diazo">
+    <copy attributes="*" content="/html" theme="/html" />
+</rules>

--- a/lib/diazo/tests/html-xml-lang-3/theme.html
+++ b/lib/diazo/tests/html-xml-lang-3/theme.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body>
+    Check that xml:lang is not output twice
+  </body>
+</html>


### PR DESCRIPTION
As discussed in email with @lrowe: when the html tag in the content includes an xml:lang attribute (as it does in Plone 4.2.2), then copying the tag's attributes results in _two_ xml:lang attributes in the output.

I've fixed the issue and added a test. All tests pass.

However, I'm not confident my fix is the best way to do it, so please review before merging.
