### PR TITLE
Simahawk 20130712 update docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -212,4 +212,4 @@ To set up the proxy, we will use `Buildout`_.
 .. _plone.app.theming: http://pypi.python.org/pypi/plone.app.theming
 .. _nginx: http://wiki.nginx.org
 .. _Buildout: http://www.buildout.org
-.. _bootstrap.py: http://svn.zope.org/*checkout*/zc.buildout/trunk/bootstrap/bootstrap.py
+.. _bootstrap.py: http://downloads.buildout.org/2/bootstrap.py


### PR DESCRIPTION
- updated buildout to 2.0 and `bootstrap.py` links accordingly;
- removed extension of outdated `http://good-py.appspot.com/release/diazo` and pinned latest version into buildout example itself. Tested manually and automatic tests passing;
- fixed broken doc for `proxy.ini` example due to redirect from `http://diazo.org/` to `http://docs.diazo.org/en/latest/index.html`.

Should I have to update also `versions.cfg`?
