### PR TITLE
Absolute prefix support for srcset attributes

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+* Absolute prefix support for srcset attributes
+  [huubbouma]
 
 
 1.2.0 (2015-09-03)

--- a/lib/diazo/rules.py
+++ b/lib/diazo/rules.py
@@ -23,6 +23,7 @@ CONDITIONAL_SRC = re.compile(
     r'''(?P<before><[^>]*?(src|href)=(?P<quote>['"]?))'''
     r'''(?P<url>[^ \t\n\r\f\v>]+)(?P<after>(?P=quote)[^>]*?>)''',
     re.IGNORECASE)
+SRCSET = re.compile(r'(?P<descriptors>^\s*|\s*,\s*)(?P<url>[^\s]*)')
 
 
 update_transform = pkg_xsl('update-namespace.xsl')
@@ -138,6 +139,13 @@ def apply_absolute_prefix(theme_doc, absolute_prefix):
     for node in theme_doc.xpath('//*[@src]'):
         url = urljoin(absolute_prefix, node.get('src'))
         node.set('src', url)
+    for node in theme_doc.xpath('//*[@srcset]'):
+        srcset = node.get('srcset')
+        srcset = SRCSET.sub(
+            lambda match: match.group('descriptors') + urljoin(
+                absolute_prefix, match.group('url')),
+            srcset)
+        node.set('srcset', srcset)
     for node in theme_doc.xpath('//*[@href]'):
         url = anchor_safe_urljoin(absolute_prefix, node.get('href'))
         node.set('href', url)

--- a/lib/diazo/tests/absolute-prefix-disabled/output.html
+++ b/lib/diazo/tests/absolute-prefix-disabled/output.html
@@ -28,6 +28,9 @@
     <img src="../foo.jpg" />
     <img src="/foo.jpg" />
     <img src="http://site.com/foo.jpg" />
+    <img srcset="http://site.com/foo.jpg 1684w" />
+    <img srcset="http://site.com/foo.jpg 1684w, foo-medium.jpg 1024w" />
+    <img srcset="large.jpg 1684w, medium.jpg 1024w, small.jpg 640w" />
     <input type="submit" src="foo.jpg" />
     <input type="submit" src="./foo.jpg" />
     <input type="submit" src="../foo.jpg" />

--- a/lib/diazo/tests/absolute-prefix-disabled/theme.html
+++ b/lib/diazo/tests/absolute-prefix-disabled/theme.html
@@ -28,6 +28,9 @@
     <img src="../foo.jpg" />
     <img src="/foo.jpg" />
     <img src="http://site.com/foo.jpg" />
+    <img srcset="http://site.com/foo.jpg 1684w" />
+    <img srcset="http://site.com/foo.jpg 1684w, foo-medium.jpg 1024w" />
+    <img srcset="large.jpg 1684w, medium.jpg 1024w, small.jpg 640w" />
     <input type="submit" src="foo.jpg" />
     <input type="submit" src="./foo.jpg" />
     <input type="submit" src="../foo.jpg" />

--- a/lib/diazo/tests/absolute-prefix/output.html
+++ b/lib/diazo/tests/absolute-prefix/output.html
@@ -28,6 +28,10 @@
     <img src="/foo.jpg" />
     <img src="/foo.jpg" />
     <img src="http://site.com/foo.jpg" />
+    <img srcset="http://site.com/foo.jpg 1684w" />
+    <img srcset="http://site.com/foo.jpg 1684w, /abs/foo-medium.jpg 1024w" />
+    <img srcset="/abs/large.jpg 1684w, /abs/medium.jpg 1024w, /abs/small.jpg 640w" />
+    <img srcset="/abs/large.jpg 1684w, /abs/medium.jpg" />
     <input type="submit" src="/abs/foo.jpg" />
     <input type="submit" src="/abs/foo.jpg" />
     <input type="submit" src="/foo.jpg" />

--- a/lib/diazo/tests/absolute-prefix/theme.html
+++ b/lib/diazo/tests/absolute-prefix/theme.html
@@ -28,6 +28,10 @@
     <img src="../foo.jpg" />
     <img src="/foo.jpg" />
     <img src="http://site.com/foo.jpg" />
+    <img srcset="http://site.com/foo.jpg 1684w" />
+    <img srcset="http://site.com/foo.jpg 1684w, foo-medium.jpg 1024w" />
+    <img srcset="large.jpg 1684w, medium.jpg 1024w, small.jpg 640w" />
+    <img srcset="large.jpg 1684w, medium.jpg" />
     <input type="submit" src="foo.jpg" />
     <input type="submit" src="./foo.jpg" />
     <input type="submit" src="../foo.jpg" />


### PR DESCRIPTION
Hi,

I had an issue with srcset attributes in my theme which had relative URLs. I needed to have them converted to absolute URLs like normal image src attributes.

Cheers, Huub