### PR TITLE
Content to content transform

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -241,6 +241,81 @@ The following attributes are allowed:
     Used to specify an element that must be present in the content for the
     drop to be performed.
 
+``<replace-content />``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Used to replace an element in the content entirely with another element from the
+content. For example::
+
+    <replace-content content="/html/body/h2" to-content="/html/body/h1"/>
+
+The (near-)equivalent using CSS selectors would be::
+
+    <replace-content css:content="h2" to-content="h1"/>
+
+The result of either is that the ``<h1 />`` element in the content is
+replaced with the ``<h2 />`` element from the same content.
+
+It might be used to re-structure content before applying the theme, but it will
+also be very useful with external content (see Advanced).
+
+The following attributes are allowed:
+
+``to-content`` or ``to-content-children`` or ``css:to-content`` or ``css:to-content-children`` (required)
+    Used to specify the node(s) in the content that is to be replaced. When using
+    ``to-content-children``, all elements inside the tag that matches the XPath
+    or CSS expression will be replaced, but the matched tag itself will remain
+    intact.
+``content`` or ``content-children`` or ``css:content`` or ``css:content-children`` (required)
+    Used to specify the node in the content that is to replace the matched
+    node(s). When using ``content-children``, all elements inside
+    the tag that matches the XPath or CSS expression will be used, but the
+    matched tag itself will be left out.
+``if``
+    Used to specify an arbitrary condition for when to perform the
+    replacement.
+``if-path``
+    Used to specify a URL path segment that must be matched by the current
+    request for the replacement to be performed
+``if-content`` or ``css:if-content``
+    Used to specify an element that must be present in the content for the
+    replacement to be performed.
+
+``<before-content />`` and ``<before-content />``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are equivalent to ``<replace-content />`` except that the node(s) matched in
+the content are inserted before or after the target node(s), respectively.
+For example::
+
+    <before-content css:content="#article" css:content="#author" />
+
+This would place the element with id ``author`` from the content
+immediately before the element with id ``article``. If we wanted the box below the
+content instead, we could do::
+
+    <after-content css:content="#article" css:content="#author" />
+
+``<before-content />`` and ``<after-content />`` have the same required and optional
+attributes as ``<replace-content />``.
+
+``<prepend-content />`` and ``<append-content />``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are equivalent to ``<replace-content />`` except that the node(s) matched in
+the content are inserted at the begining or the end of the target node(s), respectively.
+For example::
+
+    <prepend-content css:content="#article" css:content="#author" />
+
+This would place the element with id ``author`` from the content as first element of the
+element with id ``article``. If we wanted the box as last element, we could do::
+
+    <append-content css:content="#article" css:content="#author" />
+
+``<append-content />`` and ``<append-content />`` have the same required and optional
+attributes as ``<replace-content />``.
+
 ``<strip />``
 ~~~~~~~~~~~~~
 
@@ -348,20 +423,22 @@ In most cases, you should not care too much about the inner workings of the
 Diazo compiler. However, it can sometimes be useful to understand the order
 in which rules are applied.
 
-1. ``<before />`` rules using ``theme`` (but not ``theme-children``) are
-   always executed first.
-2. ``<drop />`` rules are executed next.
-3. ``<replace />`` rules using ``theme`` (but not ``theme-children``) are
+1. ``<replace-content />``, ``<before-content />``, ``<after-content />``,
+   ``<prepend-content />``, ``<append-content />`` are always executed first.
+2. ``<before />`` rules using ``theme`` (but not ``theme-children``) are
+   executed next.
+3. ``<drop />`` rules are executed next.
+4. ``<replace />`` rules using ``theme`` (but not ``theme-children``) are
    executed next, provided no ``<drop />`` rule was applied to the same theme
    node or ``method="raw"`` was used.
-4. ``<strip />`` rules are executed next. Note that ``<strip />`` rules do
+5. ``<strip />`` rules are executed next. Note that ``<strip />`` rules do
    not prevent other rules from firing, even if the content or theme node
    is going to be stripped.
-5. Rules that operate on attributes.
-6. ``<before />`` and ``<replace />`` and ``<after />`` rules using
+6. Rules that operate on attributes.
+7. ``<before />`` and ``<replace />`` and ``<after />`` rules using
    ``theme-children`` execute next, provided no ``<replace />`` rule using
    ``theme`` was applied to the same theme node previously.
-7. ``<after />`` rules using ``theme`` (but not ``theme-children``) are
+8. ``<after />`` rules using ``theme`` (but not ``theme-children``) are
    executed last.
 
 Behaviour if theme or content is not matched

--- a/lib/diazo/annotate-rules.xsl
+++ b/lib/diazo/annotate-rules.xsl
@@ -86,7 +86,7 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="diazo:insert[@href]">
+    <xsl:template match="diazo:append-content[@href]">
         <xsl:copy>
             <xsl:apply-templates select="@*|node()"/>
             <xsl:apply-templates select="." mode="include"/>

--- a/lib/diazo/annotate-rules.xsl
+++ b/lib/diazo/annotate-rules.xsl
@@ -86,6 +86,13 @@
         </xsl:copy>
     </xsl:template>
 
+    <xsl:template match="diazo:insert[@href]">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+            <xsl:apply-templates select="." mode="include"/>
+        </xsl:copy>
+    </xsl:template>
+
     <xsl:template match="/" mode="matches">
         <xsl:param name="themexpath"/>
         <xsl:param name="themeid"/>

--- a/lib/diazo/annotate-rules.xsl
+++ b/lib/diazo/annotate-rules.xsl
@@ -86,7 +86,7 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="diazo:*[local-name()='append-content' or local-name()='prepend-content'][@href]">
+    <xsl:template match="diazo:*[local-name()='append-content' or local-name()='prepend-content' or local-name()='after-content' or local-name()='before-content' or local-name()='replace-content'][@href]">
         <xsl:copy>
             <xsl:apply-templates select="@*|node()"/>
             <xsl:apply-templates select="." mode="include"/>

--- a/lib/diazo/annotate-rules.xsl
+++ b/lib/diazo/annotate-rules.xsl
@@ -86,7 +86,7 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="diazo:append-content[@href]">
+    <xsl:template match="diazo:*[local-name()='append-content' or local-name()='prepend-content'][@href]">
         <xsl:copy>
             <xsl:apply-templates select="@*|node()"/>
             <xsl:apply-templates select="." mode="include"/>

--- a/lib/diazo/cssrules.py
+++ b/lib/diazo/cssrules.py
@@ -47,7 +47,7 @@ def convert_css_selectors(rules):
                 prefix = css_prefix
             elif (tag_namespace == utils.namespaces['diazo'] and
                   localname in ('content', 'content-children', 'if-content',
-                                'if-not-content') or
+                                'if-not-content', 'to-content') or
                     (tag_namespace == utils.namespaces['xsl'] and
                      localname in ('match',))):
                 prefix = '//'

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -17,8 +17,8 @@
     <xsl:param name="known_params_url">file:///__diazo_known_params__</xsl:param>
     <xsl:param name="runtrace">0</xsl:param>
 
-    <xsl:variable name="rules" select="//dv:*[@theme or local-name()='append-content' or local-name()='prepend-content']"/>
-    <xsl:variable name="content2content-rules" select="//dv:*[local-name()='append-content' or local-name()='prepend-content']"/>
+    <xsl:variable name="rules" select="//dv:*[@theme or local-name()='append-content' or local-name()='prepend-content' or local-name()='after-content' or local-name()='before-content' or local-name()='replace-content']"/>
+    <xsl:variable name="content2content-rules" select="//dv:*[local-name()='append-content' or local-name()='prepend-content' or local-name()='after-content' or local-name()='before-content' or local-name()='replace-content']"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
     <xsl:variable name="replace-content-rules" select="//dv:replace[@content and not(@theme)]"/>
@@ -473,32 +473,46 @@
             <xsl:element name="xsl:template">
                 <xsl:attribute name="match"><xsl:value-of select="@to-content"/></xsl:attribute>
                 <xsl:attribute name="mode">content2content</xsl:attribute>
-                <xsl:text>&#10;        </xsl:text>
-                <xsl:element name="xsl:copy">
-                    <xsl:text>&#10;            </xsl:text>
-                    <xsl:choose>
-                        <xsl:when test="local-name()='append-content'">
-                            <xsl:element name="xsl:apply-templates">
-                                <xsl:attribute name="select">@*|node()</xsl:attribute>
-                            </xsl:element>
-                            <xsl:text>&#10;            </xsl:text>
-                            <xsl:call-template name="insert-into-content" />
-                        </xsl:when>
-                        <xsl:when test="local-name()='prepend-content'">
-                            <xsl:element name="xsl:apply-templates">
-                                <xsl:attribute name="select">@*</xsl:attribute>
-                            </xsl:element>
-                            <xsl:text>&#10;            </xsl:text>
-                            <xsl:call-template name="insert-into-content" />
-                            <xsl:text>&#10;            </xsl:text>
-                            <xsl:element name="xsl:apply-templates">
-                                <xsl:attribute name="select">node()</xsl:attribute>
-                            </xsl:element>
-                        </xsl:when>
-                        <xsl:otherwise></xsl:otherwise>
-                    </xsl:choose>
+                <xsl:if test="local-name()='before-content' or local-name()='replace-content'">
                     <xsl:text>&#10;        </xsl:text>
-                </xsl:element>
+                    <xsl:call-template name="insert-into-content" />
+                </xsl:if>
+                <xsl:if test="local-name()!='replace-content'">
+                    <xsl:text>&#10;        </xsl:text>
+                    <xsl:element name="xsl:copy">
+                        <xsl:text>&#10;            </xsl:text>
+                        <xsl:choose>
+                            <xsl:when test="local-name()='append-content'">
+                                <xsl:element name="xsl:apply-templates">
+                                    <xsl:attribute name="select">@*|node()</xsl:attribute>
+                                </xsl:element>
+                                <xsl:text>&#10;            </xsl:text>
+                                <xsl:call-template name="insert-into-content" />
+                            </xsl:when>
+                            <xsl:when test="local-name()='prepend-content'">
+                                <xsl:element name="xsl:apply-templates">
+                                    <xsl:attribute name="select">@*</xsl:attribute>
+                                </xsl:element>
+                                <xsl:text>&#10;            </xsl:text>
+                                <xsl:call-template name="insert-into-content" />
+                                <xsl:text>&#10;            </xsl:text>
+                                <xsl:element name="xsl:apply-templates">
+                                    <xsl:attribute name="select">node()</xsl:attribute>
+                                </xsl:element>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:element name="xsl:apply-templates">
+                                    <xsl:attribute name="select">@*|node()</xsl:attribute>
+                                </xsl:element>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <xsl:text>&#10;        </xsl:text>
+                    </xsl:element>
+                </xsl:if>
+                <xsl:if test="local-name()='after-content'">
+                    <xsl:text>&#10;        </xsl:text>
+                    <xsl:call-template name="insert-into-content" />
+                </xsl:if>
                 <xsl:text>&#10;    </xsl:text>
             </xsl:element>
             <xsl:text>&#10;</xsl:text>

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -18,6 +18,7 @@
     <xsl:param name="runtrace">0</xsl:param>
 
     <xsl:variable name="rules" select="//dv:*[@theme]"/>
+    <xsl:variable name="insert-content-rules" select="//dv:insert"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
     <xsl:variable name="replace-content-rules" select="//dv:replace[@content and not(@theme)]"/>
@@ -61,6 +62,9 @@
 
             <xsl:text>&#10;&#10;</xsl:text>
             <xsl:apply-templates select="document($known_params_url)/xsl:stylesheet/node()" />
+
+            <!-- If there are any <insert> rules, put it in here. -->
+            <xsl:call-template name="insert-content"/>
 
             <xsl:if test="$rules[@method='document']">
                 <xsl:choose>
@@ -462,6 +466,29 @@
         </xsl:choose>
     </xsl:template>
 
+    <xsl:template name="insert-content">
+        <xsl:for-each select="$insert-content-rules">
+            <xsl:text>&#10;    </xsl:text>
+            <xsl:element name="xsl:template">
+                <xsl:attribute name="match"><xsl:value-of select="@to-content"/></xsl:attribute>
+                <xsl:attribute name="mode">content2content</xsl:attribute>
+                <xsl:text>&#10;        </xsl:text>
+                <xsl:element name="xsl:copy">
+                    <xsl:text>&#10;            </xsl:text>
+                    <xsl:element name="xsl:apply-templates">
+                        <xsl:attribute name="select">@*|node()</xsl:attribute>
+                    </xsl:element>
+                    <xsl:text>&#10;            </xsl:text>
+                    <xsl:element name="xsl:apply-templates">
+                        <xsl:attribute name="select"><xsl:value-of select="@content"/></xsl:attribute>
+                    </xsl:element>
+                    <xsl:text>&#10;        </xsl:text>
+                </xsl:element>
+                <xsl:text>&#10;    </xsl:text>
+            </xsl:element>
+            <xsl:text>&#10;</xsl:text>
+        </xsl:for-each>
+    </xsl:template>
     <!--
         Debugging support
     -->

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -17,7 +17,7 @@
     <xsl:param name="known_params_url">file:///__diazo_known_params__</xsl:param>
     <xsl:param name="runtrace">0</xsl:param>
 
-    <xsl:variable name="rules" select="//dv:*[@theme]"/>
+    <xsl:variable name="rules" select="//dv:*[@theme]|//dv:insert"/>
     <xsl:variable name="insert-content-rules" select="//dv:insert"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
@@ -63,9 +63,6 @@
             <xsl:text>&#10;&#10;</xsl:text>
             <xsl:apply-templates select="document($known_params_url)/xsl:stylesheet/node()" />
 
-            <!-- If there are any <insert> rules, put it in here. -->
-            <xsl:call-template name="insert-content"/>
-
             <xsl:if test="$rules[@method='document']">
                 <xsl:choose>
                     <xsl:when test="$usebase">
@@ -94,6 +91,10 @@
                 </xsl:choose>
             </xsl:if>
             <xsl:apply-templates select="node()"/>
+
+            <!-- If there are any <insert> rules, put it in here. -->
+            <xsl:call-template name="insert-content"/>
+
             <xsl:if test="$themes">
                 <xsl:text>&#10;    </xsl:text>
                 <xsl:element name="xsl:template">
@@ -479,9 +480,16 @@
                         <xsl:attribute name="select">@*|node()</xsl:attribute>
                     </xsl:element>
                     <xsl:text>&#10;            </xsl:text>
-                    <xsl:element name="xsl:apply-templates">
-                        <xsl:attribute name="select"><xsl:value-of select="@content"/></xsl:attribute>
-                    </xsl:element>
+                    <xsl:choose>
+                        <xsl:when test="dv:synthetic">
+                            <xsl:copy-of select="dv:synthetic/node()"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:element name="xsl:apply-templates">
+                                <xsl:attribute name="select"><xsl:value-of select="@content"/></xsl:attribute>
+                            </xsl:element>
+                        </xsl:otherwise>
+                    </xsl:choose>
                     <xsl:text>&#10;        </xsl:text>
                 </xsl:element>
                 <xsl:text>&#10;    </xsl:text>

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -17,8 +17,8 @@
     <xsl:param name="known_params_url">file:///__diazo_known_params__</xsl:param>
     <xsl:param name="runtrace">0</xsl:param>
 
-    <xsl:variable name="rules" select="//dv:*[@theme]|//dv:insert"/>
-    <xsl:variable name="insert-content-rules" select="//dv:insert"/>
+    <xsl:variable name="rules" select="//dv:*[@theme]|//dv:append-content"/>
+    <xsl:variable name="append-content2content-rules" select="//dv:append-content"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
     <xsl:variable name="replace-content-rules" select="//dv:replace[@content and not(@theme)]"/>
@@ -92,8 +92,8 @@
             </xsl:if>
             <xsl:apply-templates select="node()"/>
 
-            <!-- If there are any <insert> rules, put it in here. -->
-            <xsl:call-template name="insert-content"/>
+            <!-- If there are any <append-content> rules, put it in here. -->
+            <xsl:call-template name="append-content"/>
 
             <xsl:if test="$themes">
                 <xsl:text>&#10;    </xsl:text>
@@ -467,8 +467,8 @@
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template name="insert-content">
-        <xsl:for-each select="$insert-content-rules">
+    <xsl:template name="append-content">
+        <xsl:for-each select="$append-content2content-rules">
             <xsl:text>&#10;    </xsl:text>
             <xsl:element name="xsl:template">
                 <xsl:attribute name="match"><xsl:value-of select="@to-content"/></xsl:attribute>

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -18,7 +18,7 @@
     <xsl:param name="runtrace">0</xsl:param>
 
     <xsl:variable name="rules" select="//dv:*[@theme or local-name()='append-content' or local-name()='prepend-content' or local-name()='after-content' or local-name()='before-content' or local-name()='replace-content']"/>
-    <xsl:variable name="content2content-rules" select="//dv:*[local-name()='append-content' or local-name()='prepend-content' or local-name()='after-content' or local-name()='before-content' or local-name()='replace-content']"/>
+    <xsl:variable name="unique-content2content-rules" select="//dv:*[local-name()='append-content' or local-name()='prepend-content' or local-name()='after-content' or local-name()='before-content' or local-name()='replace-content'][not(@to-content=preceding::*/@to-content)]"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
     <xsl:variable name="replace-content-rules" select="//dv:replace[@content and not(@theme)]"/>
@@ -468,51 +468,41 @@
     </xsl:template>
 
     <xsl:template name="content2content">
-        <xsl:for-each select="$content2content-rules">
+        <xsl:for-each select="$unique-content2content-rules">
+            <xsl:variable name="current" select="@to-content"/>
             <xsl:text>&#10;    </xsl:text>
             <xsl:element name="xsl:template">
-                <xsl:attribute name="match"><xsl:value-of select="@to-content"/></xsl:attribute>
+                <xsl:attribute name="match"><xsl:value-of select="$current"/></xsl:attribute>
                 <xsl:attribute name="mode">content2content</xsl:attribute>
-                <xsl:if test="local-name()='before-content' or local-name()='replace-content'">
+                <xsl:for-each select="//dv:*[local-name()='before-content' or local-name()='replace-content'][@to-content=$current]">
                     <xsl:text>&#10;        </xsl:text>
                     <xsl:call-template name="insert-into-content" />
-                </xsl:if>
-                <xsl:if test="local-name()!='replace-content'">
+                </xsl:for-each>
+                <xsl:if test="not(//dv:replace-content[@to-content=$current])">
                     <xsl:text>&#10;        </xsl:text>
                     <xsl:element name="xsl:copy">
+                        <xsl:element name="xsl:apply-templates">
+                            <xsl:attribute name="select">@*</xsl:attribute>
+                        </xsl:element>
+                        <xsl:for-each select="//dv:prepend-content[@to-content=$current]">
+                            <xsl:text>&#10;            </xsl:text>
+                            <xsl:call-template name="insert-into-content" />
+                        </xsl:for-each>
                         <xsl:text>&#10;            </xsl:text>
-                        <xsl:choose>
-                            <xsl:when test="local-name()='append-content'">
-                                <xsl:element name="xsl:apply-templates">
-                                    <xsl:attribute name="select">@*|node()</xsl:attribute>
-                                </xsl:element>
-                                <xsl:text>&#10;            </xsl:text>
-                                <xsl:call-template name="insert-into-content" />
-                            </xsl:when>
-                            <xsl:when test="local-name()='prepend-content'">
-                                <xsl:element name="xsl:apply-templates">
-                                    <xsl:attribute name="select">@*</xsl:attribute>
-                                </xsl:element>
-                                <xsl:text>&#10;            </xsl:text>
-                                <xsl:call-template name="insert-into-content" />
-                                <xsl:text>&#10;            </xsl:text>
-                                <xsl:element name="xsl:apply-templates">
-                                    <xsl:attribute name="select">node()</xsl:attribute>
-                                </xsl:element>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:element name="xsl:apply-templates">
-                                    <xsl:attribute name="select">@*|node()</xsl:attribute>
-                                </xsl:element>
-                            </xsl:otherwise>
-                        </xsl:choose>
+                        <xsl:element name="xsl:apply-templates">
+                            <xsl:attribute name="select">node()</xsl:attribute>
+                        </xsl:element>
+                        <xsl:for-each select="//dv:append-content[@to-content=$current]">
+                            <xsl:text>&#10;            </xsl:text>
+                            <xsl:call-template name="insert-into-content" />
+                        </xsl:for-each>
                         <xsl:text>&#10;        </xsl:text>
                     </xsl:element>
                 </xsl:if>
-                <xsl:if test="local-name()='after-content'">
+                <xsl:for-each select="//dv:after-content[@to-content=$current]">
                     <xsl:text>&#10;        </xsl:text>
                     <xsl:call-template name="insert-into-content" />
-                </xsl:if>
+                </xsl:for-each>
                 <xsl:text>&#10;    </xsl:text>
             </xsl:element>
             <xsl:text>&#10;</xsl:text>

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -93,7 +93,34 @@
             <xsl:if test="$themes">
                 <xsl:text>&#10;    </xsl:text>
                 <xsl:element name="xsl:template">
+                    <xsl:attribute name="match">@*|node()</xsl:attribute>
+                    <xsl:attribute name="mode">content2content</xsl:attribute>
+                    <xsl:element name="xsl:copy">
+                        <xsl:element name="xsl:apply-templates">
+                            <xsl:attribute name="select">@*|node()</xsl:attribute>
+                            <xsl:attribute name="mode">content2content</xsl:attribute>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:element>
+
+                <xsl:text>&#10;    </xsl:text>
+                <xsl:element name="xsl:template">
                     <xsl:attribute name="match">/</xsl:attribute>
+                    <xsl:element name="xsl:variable">
+                        <xsl:attribute name="name">content</xsl:attribute>
+                        <xsl:element name="xsl:apply-templates">
+                            <xsl:attribute name="mode">content2content</xsl:attribute>
+                        </xsl:element>
+                    </xsl:element>
+                    <xsl:element name="xsl:apply-templates">
+                        <xsl:attribute name="select">exsl:node-set($content)</xsl:attribute>
+                        <xsl:attribute name="mode">content2style</xsl:attribute>
+                    </xsl:element>
+                </xsl:element>
+                <xsl:text>&#10;    </xsl:text>
+                <xsl:element name="xsl:template">
+                    <xsl:attribute name="match">/</xsl:attribute>
+                    <xsl:attribute name="mode">content2style</xsl:attribute>
                     <xsl:choose>
                         <xsl:when test="$conditional">
                             <xsl:element name="xsl:choose">

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -481,13 +481,36 @@
                     </xsl:element>
                     <xsl:text>&#10;            </xsl:text>
                     <xsl:choose>
-                        <xsl:when test="dv:synthetic">
-                            <xsl:copy-of select="dv:synthetic/node()"/>
+                        <xsl:when test="@merged-condition">
+                            <xsl:element name="xsl:if">
+                                <xsl:attribute name="test">
+                                    <xsl:value-of select="@merged-condition"/>
+                                </xsl:attribute>
+                                <xsl:text>&#10;                </xsl:text>
+                                <xsl:choose>
+                                    <xsl:when test="dv:synthetic">
+                                        <xsl:copy-of select="dv:synthetic/node()"/>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:element name="xsl:apply-templates">
+                                            <xsl:attribute name="select"><xsl:value-of select="@content"/></xsl:attribute>
+                                        </xsl:element>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                                <xsl:text>&#10;            </xsl:text>
+                            </xsl:element>
                         </xsl:when>
                         <xsl:otherwise>
-                            <xsl:element name="xsl:apply-templates">
-                                <xsl:attribute name="select"><xsl:value-of select="@content"/></xsl:attribute>
-                            </xsl:element>
+                            <xsl:choose>
+                                <xsl:when test="dv:synthetic">
+                                    <xsl:copy-of select="dv:synthetic/node()"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:element name="xsl:apply-templates">
+                                        <xsl:attribute name="select"><xsl:value-of select="@content"/></xsl:attribute>
+                                    </xsl:element>
+                                </xsl:otherwise>
+                            </xsl:choose>
                         </xsl:otherwise>
                     </xsl:choose>
                     <xsl:text>&#10;        </xsl:text>

--- a/lib/diazo/normalize-rules.xsl
+++ b/lib/diazo/normalize-rules.xsl
@@ -131,8 +131,8 @@
         <xsl:attribute name="mode">raw</xsl:attribute>
     </xsl:template>
 
-    <xsl:template match="//diazo:rules/diazo:insert[@href and not(@method)]">
-        <xsl:element name="diazo:insert">
+    <xsl:template match="//diazo:rules/diazo:append-content[@href and not(@method)]">
+        <xsl:element name="diazo:append-content">
             <xsl:apply-templates select="@*"/>
             <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
             <xsl:apply-templates select="node()"/>

--- a/lib/diazo/normalize-rules.xsl
+++ b/lib/diazo/normalize-rules.xsl
@@ -131,7 +131,7 @@
         <xsl:attribute name="mode">raw</xsl:attribute>
     </xsl:template>
 
-    <xsl:template match="//diazo:rules/diazo:*[local-name()='append-content' or local-name()='prepend-content'][@href and not(@method)]">
+    <xsl:template match="//diazo:rules/diazo:*[local-name()='append-content' or local-name()='prepend-content' or local-name()='after-content' or local-name()='before-content' or local-name()='replace-content'][@href and not(@method)]">
         <xsl:element name="diazo:{local-name()}">
             <xsl:apply-templates select="@*"/>
             <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>

--- a/lib/diazo/normalize-rules.xsl
+++ b/lib/diazo/normalize-rules.xsl
@@ -131,8 +131,8 @@
         <xsl:attribute name="mode">raw</xsl:attribute>
     </xsl:template>
 
-    <xsl:template match="//diazo:rules/diazo:append-content[@href and not(@method)]">
-        <xsl:element name="diazo:append-content">
+    <xsl:template match="//diazo:rules/diazo:*[local-name()='append-content' or local-name()='prepend-content'][@href and not(@method)]">
+        <xsl:element name="diazo:{local-name()}">
             <xsl:apply-templates select="@*"/>
             <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
             <xsl:apply-templates select="node()"/>

--- a/lib/diazo/normalize-rules.xsl
+++ b/lib/diazo/normalize-rules.xsl
@@ -131,6 +131,14 @@
         <xsl:attribute name="mode">raw</xsl:attribute>
     </xsl:template>
 
+    <xsl:template match="//diazo:rules/diazo:insert[@href and not(@method)]">
+        <xsl:element name="diazo:insert">
+            <xsl:apply-templates select="@*"/>
+            <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
+            <xsl:apply-templates select="node()"/>
+        </xsl:element>
+    </xsl:template>
+
     <!--
         Debugging support
     -->

--- a/lib/diazo/tests/after-before-replace-content/content.html
+++ b/lib/diazo/tests/after-before-replace-content/content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+    <head>
+        <title>Content</title>
+    </head>
+    <body>
+    	<div id="content">
+	        <div id="header">to be replaced</div>
+	        <h2>Smaller Title</h2>
+	        <p> content </p>
+	        <div id="footer">my footer</div>
+	    </div>
+        <div id="extra">
+        	<h1>My title</h1>
+        	<span>the date</span>
+        	<strong>the author</strong>
+        </div>
+    </body>
+</html>

--- a/lib/diazo/tests/after-before-replace-content/output.html
+++ b/lib/diazo/tests/after-before-replace-content/output.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Content to content</title>
+    </head>
+    <body><div id="marker1">Marker</div><div id="marker2">Marker</div><div id="content">
+	        <h1>My title</h1>
+	        <span>the date</span><h2>Smaller Title</h2>
+	        <p> content </p><strong>the author</strong>
+	        <div id="footer">my footer</div>
+	    </div><nav></nav></body>
+</html>

--- a/lib/diazo/tests/after-before-replace-content/output.html
+++ b/lib/diazo/tests/after-before-replace-content/output.html
@@ -5,8 +5,8 @@
     </head>
     <body><div id="marker1">Marker</div><div id="marker2">Marker</div><div id="content">
 	        <h1>My title</h1>
-	        <span>the date</span><h2>Smaller Title</h2>
-	        <p> content </p><strong>the author</strong>
+	        <span>the date</span><h2>Smaller Title</h2><strong>the author</strong>
+	        <p> content </p>
 	        <div id="footer">my footer</div>
 	    </div><nav></nav></body>
 </html>

--- a/lib/diazo/tests/after-before-replace-content/rules.xml
+++ b/lib/diazo/tests/after-before-replace-content/rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://namespaces.plone.org/diazo"
+       xmlns:css="http://namespaces.plone.org/diazo/css">
+
+    <replace-content css:to-content="#header" css:content="#extra h1" />
+    <before-content css:to-content="h2" css:content="#extra span" />
+    <after-content css:to-content="p" css:content="#extra strong" />
+
+    <after theme="//*[@id='marker2']" css:content="#content"/>
+
+</rules>

--- a/lib/diazo/tests/after-before-replace-content/rules.xml
+++ b/lib/diazo/tests/after-before-replace-content/rules.xml
@@ -4,7 +4,7 @@
 
     <replace-content css:to-content="#header" css:content="#extra h1" />
     <before-content css:to-content="h2" css:content="#extra span" />
-    <after-content css:to-content="p" css:content="#extra strong" />
+    <after-content css:to-content="h2" css:content="#extra strong" />
 
     <after theme="//*[@id='marker2']" css:content="#content"/>
 

--- a/lib/diazo/tests/after-before-replace-content/theme.html
+++ b/lib/diazo/tests/after-before-replace-content/theme.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+    <head>
+        <title>Content to content</title>
+    </head>
+    <body>
+        <div id="marker1">Marker</div>
+        <div id="marker2">Marker</div>
+        <nav />
+    </body>
+</html>

--- a/lib/diazo/tests/conditional-content-to-content/content.html
+++ b/lib/diazo/tests/conditional-content-to-content/content.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+    <head>
+        <title>Content</title>
+    </head>
+    <body>
+        <div id="header">Here is a copy of my H2:</div>
+        The original H2 is here <h2>Smaller Title</h2>
+        <p> content </p>
+        <div id="footer">Here I get another H2 from an external page:</div>
+    </body>
+</html>

--- a/lib/diazo/tests/conditional-content-to-content/extra.html
+++ b/lib/diazo/tests/conditional-content-to-content/extra.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <h2 id="external1">
+            ONE
+        </h2>
+    </body>
+</html>

--- a/lib/diazo/tests/conditional-content-to-content/output.html
+++ b/lib/diazo/tests/conditional-content-to-content/output.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Content to content</title>
+    </head>
+    <body><div id="marker1">Marker</div><div id="marker2">Marker</div><div id="header">Here is a copy of my H2:</div><h2>Smaller Title</h2><p> content </p><div id="footer">Here I get another H2 from an external page:<h2 id="external1">
+            ONE
+        </h2></div><nav><h2>Smaller Title</h2><h2 id="external1">
+            ONE
+        </h2></nav></body>
+</html>

--- a/lib/diazo/tests/conditional-content-to-content/rules.xml
+++ b/lib/diazo/tests/conditional-content-to-content/rules.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://namespaces.plone.org/diazo"
+       xmlns:css="http://namespaces.plone.org/diazo/css">
+
+    <!-- local insert -->
+    <rules css:if-content=".not-found">
+	    <append-content css:to-content="#header" css:content="h2" />
+	</rules>
+
+    <!-- insert from external content to content -->
+    <rules css:if-content="#footer">
+    	<append-content css:to-content="#footer" css:content="#external1" href="extra.html"/>
+    </rules>
+
+    <!-- the resulting content can be used in regular theme rules -->
+    <copy css:theme="nav" css:content="h2" />
+
+    <after theme="//*[@id='marker2']" content="/html/body/*"/>
+
+</rules>

--- a/lib/diazo/tests/conditional-content-to-content/theme.html
+++ b/lib/diazo/tests/conditional-content-to-content/theme.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+    <head>
+        <title>Content to content</title>
+    </head>
+    <body>
+        <div id="marker1">Marker</div>
+        <div id="marker2">Marker</div>
+        <nav />
+    </body>
+</html>

--- a/lib/diazo/tests/content-to-content/content.html
+++ b/lib/diazo/tests/content-to-content/content.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+    <head>
+        <title>Content</title>
+    </head>
+    <body>
+        <div id="header">Here is a copy of my H2:</div>
+        The original H2 is here <h2>Smaller Title</h2>
+        <p> content </p>
+        <div id="footer">Here I get another H2 from an external page:</div>
+    </body>
+</html>

--- a/lib/diazo/tests/content-to-content/content.html
+++ b/lib/diazo/tests/content-to-content/content.html
@@ -4,7 +4,7 @@
         <title>Content</title>
     </head>
     <body>
-        <div id="header">Here is a copy of my H2:</div>
+        <div id="header">(that's a copy of my own H2)</div>
         The original H2 is here <h2>Smaller Title</h2>
         <p> content </p>
         <div id="footer">Here I get another H2 from an external page:</div>

--- a/lib/diazo/tests/content-to-content/extra.html
+++ b/lib/diazo/tests/content-to-content/extra.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <h2 id="external1">
+            ONE
+        </h2>
+    </body>
+</html>

--- a/lib/diazo/tests/content-to-content/output.html
+++ b/lib/diazo/tests/content-to-content/output.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
     <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <title>Content to content</title>
     </head>
-    <body><div id="marker1">Marker</div><div id="marker2">Marker</div><div id="header">Here is a copy of my H2:<h2>Smaller Title</h2></div><h2>Smaller Title</h2><p> content </p><div id="footer">Here I get and H2 from an external page:<h2 id="external1">
+    <body><div id="marker1">Marker</div><div id="marker2">Marker</div><div id="header">Here is a copy of my H2:<h2>Smaller Title</h2></div><h2>Smaller Title</h2><p> content </p><div id="footer">Here I get another H2 from an external page:<h2 id="external1">
             ONE
         </h2></div><nav><h2>Smaller Title</h2><h2>Smaller Title</h2><h2 id="external1">
             ONE

--- a/lib/diazo/tests/content-to-content/output.html
+++ b/lib/diazo/tests/content-to-content/output.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml">
+    <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Content to content</title>
+    </head>
+    <body><div id="marker1">Marker</div><div id="marker2">Marker</div><div id="header">Here is a copy of my H2:<h2>Smaller Title</h2></div><h2>Smaller Title</h2><p> content </p><div id="footer">Here I get and H2 from an external page:<h2 id="external1">
+            ONE
+        </h2></div><nav><h2>Smaller Title</h2><h2>Smaller Title</h2><h2 id="external1">
+            ONE
+        </h2></nav></body>
+</html>

--- a/lib/diazo/tests/content-to-content/output.html
+++ b/lib/diazo/tests/content-to-content/output.html
@@ -3,7 +3,7 @@
     <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <title>Content to content</title>
     </head>
-    <body><div id="marker1">Marker</div><div id="marker2">Marker</div><div id="header">Here is a copy of my H2:<h2>Smaller Title</h2></div><h2>Smaller Title</h2><p> content </p><div id="footer">Here I get another H2 from an external page:<h2 id="external1">
+    <body><div id="marker1">Marker</div><div id="marker2">Marker</div><div id="header"><h2>Smaller Title</h2>(that's a copy of my own H2)</div><h2>Smaller Title</h2><p> content </p><div id="footer">Here I get another H2 from an external page:<h2 id="external1">
             ONE
         </h2></div><nav><h2>Smaller Title</h2><h2>Smaller Title</h2><h2 id="external1">
             ONE

--- a/lib/diazo/tests/content-to-content/rules.xml
+++ b/lib/diazo/tests/content-to-content/rules.xml
@@ -3,10 +3,10 @@
        xmlns:css="http://namespaces.plone.org/diazo/css">
 
     <!-- local insert -->
-    <insert css:to-content="#header" css:content="h2" />
+    <append-content css:to-content="#header" css:content="h2" />
 
     <!-- insert from external content to content -->
-    <insert css:to-content="#footer" css:content="#external1" href="extra.html"/>
+    <append-content css:to-content="#footer" css:content="#external1" href="extra.html"/>
 
     <!-- the resulting content can be used in regular theme rules -->
     <copy css:theme="nav" css:content="h2" />

--- a/lib/diazo/tests/content-to-content/rules.xml
+++ b/lib/diazo/tests/content-to-content/rules.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://namespaces.plone.org/diazo"
+       xmlns:css="http://namespaces.plone.org/diazo/css">
+
+    <!-- local insert -->
+    <insert css:to-content="#header" css:content="h2" />
+
+    <!-- insert from external content to content -->
+    <insert css:to-content="#footer" css:content="#external1" href="extra.html"/>
+
+    <!-- the resulting content can be used in regular theme rules -->
+    <copy css:theme="nav" css:content="h2" />
+
+    <after theme="//*[@id='marker2']" content="/html/body/*"/>
+
+</rules>

--- a/lib/diazo/tests/content-to-content/rules.xml
+++ b/lib/diazo/tests/content-to-content/rules.xml
@@ -3,7 +3,7 @@
        xmlns:css="http://namespaces.plone.org/diazo/css">
 
     <!-- local insert -->
-    <append-content css:to-content="#header" css:content="h2" />
+    <prepend-content css:to-content="#header" css:content="h2" />
 
     <!-- insert from external content to content -->
     <append-content css:to-content="#footer" css:content="#external1" href="extra.html"/>

--- a/lib/diazo/tests/content-to-content/theme.html
+++ b/lib/diazo/tests/content-to-content/theme.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+    <head>
+        <title>Content to content</title>
+    </head>
+    <body>
+        <div id="marker1">Marker</div>
+        <div id="marker2">Marker</div>
+        <nav />
+    </body>
+</html>


### PR DESCRIPTION
## Principle
This PR adds the following rules: `replace-content`, `before-content`, `after-content`, `prepend-content` and `append-content`.
Those rules allow to modify the content before applying the theme. A typical example would be:
```xml
    <!-- local insert -->
    <prepend-content css:to-content="#header" css:content="h2" />

    <!-- insert from external content to content -->
    <append-content css:to-content="#footer" css:content="h2" href="extra.html"/>

    <!-- the resulting content can be used in regular theme rules -->
    <copy css:theme="nav" css:content="h2" />
```
## Objective
In many cases, our Diazo themes are based on big blocks (like header / content / side columns / footer). If we want to dispatch very granularly the content elements, it implies to create a very detailed theme markup, which is difficult to maintain, and lakes of flexibility (for instance if we want to refactor our grid system).
Those rules provide a powerful way to re-organize elements which might be located in a quite deep location in the content document, and keeping a quite simple theme page structure.
Moreover, they also allow (using the `href` attributes) to inject external contents into the current content, which can be handy to aggregate contents without needing specific slots in the theme markup.

## Implementation
Regarding the implementation, it does not pollute the existing processing, it just adds a new mode (named `content2content`) in the resulting stylesheet, this mode is called before the existing `content2style` mode. It should have no impact on performances for existing Diazo themes using the currently existing rules.

@lrowe, please have a look when you have a moment.