### PR TITLE
Content to content inclusion

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+* Allow content-to-content inclusion
+  [ebrehault]
 
 
 1.1.0 (2014-10-23)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -251,7 +251,8 @@ Inline markup and XSLT may be combined with conditions::
 Modifying the content on the fly
 --------------------------------
 
-It is possible to modify the included content using ``<replace />``.
+It is possible to modify the included content using ``<replace />``,
+``<before />``, or ``<after />``.
 
 For example::
 
@@ -260,6 +261,10 @@ For example::
             <img src="images/search.png" alt="Search" />
         </button>
     </replace>
+
+    <before css:content="#content-core">
+        <a href="mailto:contact@diazo.org">Ask for help</a>
+    </before>
 
 This may be combined with conditions and inline XSLT.
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -266,7 +266,21 @@ For example::
         <a href="mailto:contact@diazo.org">Ask for help</a>
     </before>
 
-This may be combined with conditions and inline XSLT.
+The content can be inline HTML or it can be a piece of content from the document
+itself retrieved using the ``<include />`` tag. For instance::
+
+    <before css:content-children="#main">
+        <include css:content="#breadcrumbs" />
+    </before>
+
+The ``<include />`` tag accepts a ``href`` attribute, so it can retrieve a piece
+of content from another page. For instance::
+
+    <after css:content="#main">
+        <include css:content="form" href="contact.html" />
+    </after>
+
+This may also be combined with conditions and inline XSLT.
 
 Warning: it is not possible to both modify the content children and put them in
 the theme, for instance::

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -268,6 +268,32 @@ For example::
 
 This may be combined with conditions and inline XSLT.
 
+Warning: it is not possible to both modify the content children and put them in
+the theme, for instance::
+
+    <before css:content-children="#one">
+        <span>Uno</span>
+    </before>
+
+    <before
+        css:theme="#alpha"
+        css:content-children="#one"
+        />
+
+would not work. But::
+
+    <before css:content-children="#one">
+        <span>Uno</span>
+    </before>
+
+    <before
+        css:theme="#alpha"
+        css:content="#one"
+        />
+
+would work (because the theme rule targets the `#one` content, not its
+children).
+
 Inline XSL directives
 ---------------------
 

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -20,7 +20,7 @@
     <xsl:variable name="rules" select="//dv:*[@theme]"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
-    <xsl:variable name="replace-content-rules" select="//dv:replace[@content and not(@theme)]"/>
+    <xsl:variable name="before-replace-after-content-selectors" select="//dv:*[local-name()='before' or local-name()='replace' or local-name()='after'][@content and not(@theme)]/@content"/>
     <xsl:variable name="replace-content-children-rules" select="//dv:replace[@content-children and not(@theme)]"/>
     <xsl:variable name="inline-xsl" select="/dv:rules/xsl:*"/>
     <xsl:variable name="themes" select="//dv:theme"/>
@@ -198,7 +198,7 @@
             <xsl:call-template name="strip-content"/>
             <!-- If there are any <replace @content> rules, put it in
             here. -->
-            <xsl:call-template name="replace-content"/>
+            <xsl:call-template name="before-replace-after-content"/>
             <!-- If there are any <replace @content-children> rules, put it in
             here. -->
             <xsl:call-template name="replace-content-children"/>
@@ -335,34 +335,160 @@
         </xsl:for-each>
     </xsl:template>
 
-    <xsl:template name="replace-content">
-        <xsl:for-each select="$replace-content-rules">
-            <xsl:text>&#10;    </xsl:text>
-            <xsl:call-template name="debug-comment" select="."/>
-            <xsl:text>&#10;    </xsl:text>
-            <xsl:element name="xsl:template">
-                <xsl:attribute name="match">
-                    <xsl:value-of select="@content"/>
-                    <xsl:if test="@merged-condition">
-                        <xsl:text>[</xsl:text>
-                        <xsl:choose>
-                            <xsl:when test="contains(@merged-condition, '$')">
-                                <!-- variable references are not allowed in template match patterns -->
-                                <xsl:text>dyn:evaluate(</xsl:text>
-                                <xsl:call-template name="escape-string">
-                                    <xsl:with-param name="string" select="@merged-condition"/>
-                                </xsl:call-template>
-                                <xsl:text>)</xsl:text>
-                            </xsl:when>
-                            <xsl:otherwise><xsl:value-of select="@merged-condition"/></xsl:otherwise>
-                        </xsl:choose>
-                        <xsl:text>]</xsl:text>
+    <xsl:template name="before-replace-after-content">
+        <xsl:for-each select="$before-replace-after-content-selectors">
+            <xsl:variable name="current" select="."/>
+            <xsl:variable name="matching-before" select="//dv:before[@content=$current and not(@theme)]"/>
+            <xsl:variable name="matching-replace" select="//dv:replace[@content=$current and not(@theme)]"/>
+            <xsl:variable name="matching-after" select="//dv:after[@content=$current and not(@theme)]"/>
+            <!-- filter so we get each selector only once -->
+            <xsl:if test="generate-id() = generate-id($before-replace-after-content-selectors[. = $current][1])">
+                <xsl:text>&#10;    </xsl:text>
+                <xsl:element name="xsl:template">
+                    <xsl:attribute name="match">
+                        <xsl:value-of select="$current"/>
+                    </xsl:attribute>
+                    <xsl:if test="$matching-before">
+                        <xsl:text>&#10;        </xsl:text>
+                        <xsl:element name="xsl:apply-templates">
+                            <xsl:attribute name="select">.</xsl:attribute>
+                            <xsl:attribute name="mode">before-content</xsl:attribute>
+                        </xsl:element>
                     </xsl:if>
-                </xsl:attribute>
-                <xsl:copy-of select="node()"/>
-            </xsl:element>
-            <xsl:text>&#10;</xsl:text>
+                    <xsl:choose>
+                        <xsl:when test="$matching-replace">
+                            <xsl:text>&#10;        </xsl:text>
+                            <xsl:element name="xsl:apply-templates">
+                                <xsl:attribute name="select">.</xsl:attribute>
+                                <xsl:attribute name="mode">replace-content</xsl:attribute>
+                            </xsl:element>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:call-template name="include-content" />
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    <xsl:if test="$matching-after">
+                        <xsl:text>&#10;        </xsl:text>
+                        <xsl:element name="xsl:apply-templates">
+                            <xsl:attribute name="select">.</xsl:attribute>
+                            <xsl:attribute name="mode">after-content</xsl:attribute>
+                        </xsl:element>
+                    </xsl:if>
+                    <xsl:text>&#10;    </xsl:text>
+                </xsl:element>
+
+                <xsl:if test="$matching-before">
+                    <xsl:text>&#10;    </xsl:text>
+                    <xsl:element name="xsl:template">
+                        <xsl:attribute name="match">
+                            <xsl:value-of select="$current"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="mode">before-content</xsl:attribute>
+                        <xsl:call-template name="include-all-with-condition">
+                            <xsl:with-param name="matching-rules" select="$matching-before" />
+                        </xsl:call-template>
+                    </xsl:element>
+                    <xsl:text>&#10;    </xsl:text>
+                </xsl:if>
+
+                <xsl:if test="$matching-replace">
+                    <xsl:text>&#10;    </xsl:text>
+                    <xsl:element name="xsl:template">
+                        <xsl:attribute name="match">
+                            <xsl:value-of select="$current"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="mode">replace-content</xsl:attribute>
+                        <xsl:choose>
+                            <xsl:when test="$matching-replace[@merged-condition]">
+                                <xsl:element name="xsl:choose">
+                                    <xsl:for-each select="$matching-replace">
+                                        <xsl:text>&#10;        </xsl:text>
+                                        <xsl:choose>
+                                            <xsl:when test="@merged-condition">
+                                                <xsl:element name="xsl:when">
+                                                    <xsl:attribute name="test">
+                                                        <xsl:choose>
+                                                            <xsl:when test="contains(@merged-condition, '$')">
+                                                                <!-- variable references are not allowed in template match patterns -->
+                                                                <xsl:text>dyn:evaluate(</xsl:text>
+                                                                <xsl:call-template name="escape-string">
+                                                                    <xsl:with-param name="string" select="@merged-condition"/>
+                                                                </xsl:call-template>
+                                                                <xsl:text>)</xsl:text>
+                                                            </xsl:when>
+                                                            <xsl:otherwise><xsl:value-of select="@merged-condition"/></xsl:otherwise>
+                                                        </xsl:choose>
+                                                    </xsl:attribute>
+                                                    <xsl:copy-of select="node()"/>
+                                                </xsl:element>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:copy-of select="node()"/>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
+                                    </xsl:for-each>
+                                    <xsl:element name="xsl:otherwise">
+                                        <xsl:call-template name="include-content" />
+                                    </xsl:element>
+                                    <xsl:text>&#10;    </xsl:text>
+                                </xsl:element>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:for-each select="$matching-replace">
+                                    <xsl:copy-of select="node()"/>
+                                </xsl:for-each>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                    <xsl:text>&#10;    </xsl:text>
+                </xsl:if>
+
+                <xsl:if test="$matching-after">
+                    <xsl:text>&#10;    </xsl:text>
+                    <xsl:element name="xsl:template">
+                        <xsl:attribute name="match">
+                            <xsl:value-of select="$current"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="mode">after-content</xsl:attribute>
+                        <xsl:call-template name="include-all-with-condition">
+                            <xsl:with-param name="matching-rules" select="$matching-after" />
+                        </xsl:call-template>
+                    </xsl:element>
+                    <xsl:text>&#10;    </xsl:text>
+                </xsl:if>
+            </xsl:if>
         </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="include-all-with-condition">
+        <xsl:param name="matching-rules"/>
+        <xsl:for-each select="$matching-rules">
+            <xsl:text>&#10;        </xsl:text>
+            <xsl:choose>
+                <xsl:when test="@merged-condition">
+                    <xsl:element name="xsl:if">
+                        <xsl:attribute name="test">
+                            <xsl:choose>
+                                <xsl:when test="contains(@merged-condition, '$')">
+                                    <!-- variable references are not allowed in template match patterns -->
+                                    <xsl:text>dyn:evaluate(</xsl:text>
+                                    <xsl:call-template name="escape-string">
+                                        <xsl:with-param name="string" select="@merged-condition"/>
+                                    </xsl:call-template>
+                                    <xsl:text>)</xsl:text>
+                                </xsl:when>
+                                <xsl:otherwise><xsl:value-of select="@merged-condition"/></xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:copy-of select="node()"/>
+                    </xsl:element>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:copy-of select="node()"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+        <xsl:text>&#10;    </xsl:text>
     </xsl:template>
 
     <xsl:template name="replace-content-children">

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -18,6 +18,7 @@
     <xsl:param name="runtrace">0</xsl:param>
 
     <xsl:variable name="rules" select="//dv:*[@theme]"/>
+    <xsl:variable name="external-includes" select="//dv:rules[@external-includes]"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
     <xsl:variable name="before-replace-after-content-selectors" select="//dv:*[local-name()='before' or local-name()='replace' or local-name()='after'][@content and not(@theme) and not(@content-children)]/@content|//dv:*[local-name()='before' or local-name()='replace' or local-name()='after'][@content and not(@theme) and @content-children]/@content-children"/>
@@ -62,7 +63,7 @@
             <xsl:text>&#10;&#10;</xsl:text>
             <xsl:apply-templates select="document($known_params_url)/xsl:stylesheet/node()" />
 
-            <xsl:if test="$rules[@method='document']">
+            <xsl:if test="$rules[@method='document']|$external-includes">
                 <xsl:choose>
                     <xsl:when test="$usebase">
                         <!-- When usebase is true, document() includes are resolved internally using the base tag -->

--- a/lib/diazo/normalize-rules.xsl
+++ b/lib/diazo/normalize-rules.xsl
@@ -31,6 +31,9 @@
     <xsl:template match="/diazo:rules">
         <xsl:element name="diazo:{local-name()}">
             <xsl:attribute name="css:dummy"/>
+            <xsl:if test=".//diazo:include[@href]">
+                <xsl:attribute name="external-includes">1</xsl:attribute>
+            </xsl:if>
             <xsl:apply-templates select="@*|node()"/>
         </xsl:element>
     </xsl:template>
@@ -129,6 +132,24 @@
             </xsl:call-template>
         </xsl:if>
         <xsl:attribute name="mode">raw</xsl:attribute>
+    </xsl:template>
+
+    <xsl:template match="//diazo:include">
+        <xsl:element name="xsl:apply-templates">
+            <xsl:if test="@href">
+                <xsl:attribute name="method">document</xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="select">
+                <xsl:choose>
+                    <xsl:when test="@href">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="@content"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+            <xsl:attribute name="mode">raw</xsl:attribute>
+        </xsl:element>
     </xsl:template>
 
     <!--

--- a/lib/diazo/tests/before-content-conditional/content.html
+++ b/lib/diazo/tests/before-content-conditional/content.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <div id="#main">
+      <p id="one">one</p>
+      <p id="two">two</p>
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/before-content-conditional/output.html
+++ b/lib/diazo/tests/before-content-conditional/output.html
@@ -2,9 +2,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <body>
     <h1>Title</h1>
-    <div id="alpha"></div>
-    <p id="one">one</p>
     <span>Uno</span>
+    <span>Un</span>
+    <p id="one">one</p>
+    <div id="alpha"></div>
     <div id="beta"></div>
   </body>
 </html>
+

--- a/lib/diazo/tests/before-content-conditional/rules.xml
+++ b/lib/diazo/tests/before-content-conditional/rules.xml
@@ -4,20 +4,22 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     >
 
-    <after css:content="#one">
+    <before css:content="#one">
         <span>Uno</span>
-    </after>
+    </before>
 
-    <after
+    <before css:content="#one" css:if-content="#two">
+        <span>Un</span>
+    </before>
+
+    <before css:content="#one" css:if-content="#no-match">
+        <span>Uchi</span>
+    </before>
+    
+    <before
         css:theme="#alpha"
         css:content="#one"
         css:if-content="#two"
-        />
-
-    <after
-        css:theme="#beta"
-        css:content="#two"
-        css:if-content="#three"
         />
 
 </rules>

--- a/lib/diazo/tests/before-content-conditional/theme.html
+++ b/lib/diazo/tests/before-content-conditional/theme.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+  <h1>Title</h1>
+  <div id="alpha"></div>
+  <div id="beta"></div>
+</body>
+</html>

--- a/lib/diazo/tests/include-content/content.html
+++ b/lib/diazo/tests/include-content/content.html
@@ -1,0 +1,14 @@
+<html>
+  <body>
+      <div id="breadcrumbs">
+          <span id="you-are-here">You are here</span>
+      </div>
+      <span id="date">2015-04-02</span>
+      <div id="source-content">
+          <article>
+              <h1>Title</h1>
+              <section>Description</section>
+          </article>
+      </div>
+  </body>
+</html>

--- a/lib/diazo/tests/include-content/extra.html
+++ b/lib/diazo/tests/include-content/extra.html
@@ -1,0 +1,6 @@
+<div id="related">
+    Document 2
+</div>
+<div id="portlet">
+    Portlet
+</div>

--- a/lib/diazo/tests/include-content/output.html
+++ b/lib/diazo/tests/include-content/output.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div id="source-content">
+      <div id="breadcrumbs">
+        <span id="you-are-here">You are here</span>
+      </div>
+      <article>
+        <h1>Title</h1>
+        <span id="date">2015-04-02</span>
+        <section>Description</section>
+        <div id="related">
+          Document 2
+        </div>
+      </article>
+    </div>
+    <div id="portlet">
+      Portlet
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/include-content/rules.xml
+++ b/lib/diazo/tests/include-content/rules.xml
@@ -1,0 +1,28 @@
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    >
+
+    <before css:content-children="#source-content">
+        <include css:content="#breadcrumbs" />
+    </before>
+
+    <after css:content="h1">
+        <include css:content="#date" />
+    </after>
+
+    <replace css:theme="#footer">
+        <include css:content="#portlet" href="extra.html" />
+    </replace>
+
+    <after css:content="section">
+        <include css:content="#related" href="extra.html" />
+    </after>
+    
+    <replace
+        css:theme="#target-content"
+        css:content="#source-content"
+        />
+
+</rules>

--- a/lib/diazo/tests/include-content/theme.html
+++ b/lib/diazo/tests/include-content/theme.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <div id="target-content"></div>
+  <div id="footer"></div>
+</body>
+</html>

--- a/lib/diazo/tests/v1-after-content-children/output.html
+++ b/lib/diazo/tests/v1-after-content-children/output.html
@@ -3,7 +3,7 @@
   <body>
     <div>
     <h1>Title</h1>
-    <div id="alpha">text</div>one
+    <div id="alpha">text</div>one<span>Uno</span>
     <div id="beta"><span>b</span></div>two
     <div id="delta"><span>d</span></div><span>three</span>
   </div>

--- a/lib/diazo/tests/v1-after-content-children/output.html
+++ b/lib/diazo/tests/v1-after-content-children/output.html
@@ -3,8 +3,8 @@
   <body>
     <div>
     <h1>Title</h1>
-    <div id="alpha">text</div>one<span>Uno</span>
-    <div id="beta"><span>b</span></div>two
+    <div id="alpha">text</div>one
+    <div id="beta"><span>b</span></div><p id="two">two<span>Uno</span></p>
     <div id="delta"><span>d</span></div><span>three</span>
   </div>
   </body>

--- a/lib/diazo/tests/v1-after-content-children/rules.xml
+++ b/lib/diazo/tests/v1-after-content-children/rules.xml
@@ -4,6 +4,10 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     >
 
+    <after css:content-children="#one">
+        <span>Uno</span>
+    </after>
+
     <after
         css:theme="#alpha"
         css:content-children="#one"

--- a/lib/diazo/tests/v1-after-content-children/rules.xml
+++ b/lib/diazo/tests/v1-after-content-children/rules.xml
@@ -4,7 +4,13 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     >
 
+    <!-- will not work -->
     <after css:content-children="#one">
+        <span>Uno</span>
+    </after>
+
+    <!-- will work -->
+    <after css:content-children="#two">
         <span>Uno</span>
     </after>
 
@@ -15,7 +21,7 @@
 
     <after
         css:theme="#beta"
-        css:content-children="#two"
+        css:content="#two"
         />
 
     <after

--- a/lib/diazo/tests/v1-before-content-children/output.html
+++ b/lib/diazo/tests/v1-before-content-children/output.html
@@ -3,7 +3,7 @@
   <body>
     <div>
       <h1>Title</h1>
-      one<div id="alpha">text</div>
+      <span>Uno</span>one<div id="alpha">text</div>
       two<div id="beta"><span>b</span></div>
       <span>three</span><div id="delta"><span>d</span></div>
     </div>

--- a/lib/diazo/tests/v1-before-content-children/output.html
+++ b/lib/diazo/tests/v1-before-content-children/output.html
@@ -3,8 +3,8 @@
   <body>
     <div>
       <h1>Title</h1>
-      <span>Uno</span>one<div id="alpha">text</div>
-      two<div id="beta"><span>b</span></div>
+      one<div id="alpha">text</div>
+      <p id="two"><span>Uno</span>two</p><div id="beta"><span>b</span></div>
       <span>three</span><div id="delta"><span>d</span></div>
     </div>
   </body>

--- a/lib/diazo/tests/v1-before-content-children/rules.xml
+++ b/lib/diazo/tests/v1-before-content-children/rules.xml
@@ -4,6 +4,10 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     >
 
+    <before css:content-children="#one">
+        <span>Uno</span>
+    </before>
+    
     <before
         css:theme="#alpha"
         css:content-children="#one"

--- a/lib/diazo/tests/v1-before-content-children/rules.xml
+++ b/lib/diazo/tests/v1-before-content-children/rules.xml
@@ -4,10 +4,16 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     >
 
+    <!-- will not work -->
     <before css:content-children="#one">
         <span>Uno</span>
     </before>
-    
+
+    <!-- will work -->
+    <before css:content-children="#two">
+        <span>Uno</span>
+    </before>
+
     <before
         css:theme="#alpha"
         css:content-children="#one"
@@ -15,7 +21,7 @@
 
     <before
         css:theme="#beta"
-        css:content-children="#two"
+        css:content="#two"
         />
 
     <before

--- a/lib/diazo/tests/v1-before-content-content-children/content.html
+++ b/lib/diazo/tests/v1-before-content-content-children/content.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <p id="one"><span>one</span><span>1</span></p>
+  </body>
+</html>

--- a/lib/diazo/tests/v1-before-content-content-children/output.html
+++ b/lib/diazo/tests/v1-before-content-content-children/output.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <h1>Title</h1>
+    <p id="one">
+        <span>before</span>
+        <span>one</span>
+        <span>1</span>
+    </p>
+  </body>
+</html>

--- a/lib/diazo/tests/v1-before-content-content-children/rules.xml
+++ b/lib/diazo/tests/v1-before-content-content-children/rules.xml
@@ -1,0 +1,16 @@
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    >
+
+    <before css:content-children="#one">
+        <span>before</span>
+    </before>
+
+    <replace
+        css:theme="#alpha"
+        css:content="#one"
+        />
+
+</rules>

--- a/lib/diazo/tests/v1-before-content-content-children/theme.html
+++ b/lib/diazo/tests/v1-before-content-content-children/theme.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <h1>Title</h1>
+  <div id="alpha"></div>
+</body>
+</html>

--- a/lib/diazo/tests/v1-before-replace-after-content/content.html
+++ b/lib/diazo/tests/v1-before-replace-after-content/content.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <p id="one" class="after">one</p>
+  </body>
+</html>

--- a/lib/diazo/tests/v1-before-replace-after-content/output.html
+++ b/lib/diazo/tests/v1-before-replace-after-content/output.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <h1>Title</h1>
+    <span>before</span>
+    <span>replace</span>
+    <span>after</span>
+  </body>
+</html>

--- a/lib/diazo/tests/v1-before-replace-after-content/rules.xml
+++ b/lib/diazo/tests/v1-before-replace-after-content/rules.xml
@@ -1,0 +1,24 @@
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    >
+
+    <before css:content="#one">
+        <span>before</span>
+    </before>
+
+    <replace css:content="#one">
+        <span>replace</span>
+    </replace>
+
+    <after css:content=".after">
+        <span>after</span>
+    </after>
+
+    <replace
+        css:theme="#alpha"
+        css:content="#one"
+        />
+
+</rules>

--- a/lib/diazo/tests/v1-before-replace-after-content/theme.html
+++ b/lib/diazo/tests/v1-before-replace-after-content/theme.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <h1>Title</h1>
+  <div id="alpha"></div>
+</body>
+</html>

--- a/lib/diazo/tests/v1-before/output.html
+++ b/lib/diazo/tests/v1-before/output.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <body>
     <h1>Title</h1>
+    <span>Uno</span>
     <p id="one">one</p>
     <div id="alpha"></div>
     <div id="beta"></div>

--- a/lib/diazo/tests/v1-before/rules.xml
+++ b/lib/diazo/tests/v1-before/rules.xml
@@ -4,6 +4,10 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     >
 
+    <before css:content="#one">
+        <span>Uno</span>
+    </before>
+    
     <before
         css:theme="#alpha"
         css:content="#one"


### PR DESCRIPTION
## Principle
The previous PR #43 allows on-the-fly content modification.
With this PR, instead of inserting hard-coded HTML, we have a new tag `<include />` able to retrive a piece of content from the document itself retrieved. For instance:
```xml
 <before css:content-children="#main">
    <include css:content="#breadcrumbs" />
</before>
```
The `<include />` tag accepts a `href` attribute, so it can retrieve a piece of content from another page. For instance:
```xml
<after css:content="#main">
    <include css:content="form" href="contact.html" />
</after>
```

## Implementation
As discussed in #42, the `include ` tag is just a simpler syntax for:
```xml
<xsl:apply-templates select="..." mode="raw"/>
```

@lrowe I have fork it from the my #43 branch before merging with the Python 3 changes (as they broke the tests).