### PR TITLE
Include content review

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,16 +4,17 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+* Allow content-to-content inclusion
+  [ebrehault]
+
 * Fixed issue with remote themes via https connections
   [loechel]
-
 
 1.1.1 (2015-03-21)
 ------------------
 
 * Make flake8 happy by moving imports to top of file.
   [elro]
-
 
 1.1.0 (2014-10-23)
 ------------------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -266,7 +266,21 @@ For example::
         <a href="mailto:contact@diazo.org">Ask for help</a>
     </before>
 
-This may be combined with conditions and inline XSLT.
+The content can be inline HTML or it can be a piece of content from the document
+itself retrieved using the ``<include />`` tag. For instance::
+
+    <before css:content-children="#main">
+        <include css:content="#breadcrumbs" />
+    </before>
+
+The ``<include />`` tag accepts a ``href`` attribute, so it can retrieve a piece
+of content from another page. For instance::
+
+    <after css:content="#main">
+        <include css:content="form" href="contact.html" />
+    </after>
+
+This may also be combined with conditions and inline XSLT.
 
 Warning: it is not possible to both modify the content children and put them in
 the theme, for instance::

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -18,6 +18,7 @@
     <xsl:param name="runtrace">0</xsl:param>
 
     <xsl:variable name="rules" select="//dv:*[@theme]"/>
+    <xsl:variable name="external-includes" select="//dv:rules[@external-includes]"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
     <xsl:variable name="before-replace-after-content-selectors" select="//dv:*[local-name()='before' or local-name()='replace' or local-name()='after'][@content and not(@theme) and not(@content-children)]/@content|//dv:*[local-name()='before' or local-name()='replace' or local-name()='after'][@content and not(@theme) and @content-children]/@content-children"/>
@@ -62,7 +63,7 @@
             <xsl:text>&#10;&#10;</xsl:text>
             <xsl:apply-templates select="document($known_params_url)/xsl:stylesheet/node()" />
 
-            <xsl:if test="$rules[@method='document']">
+            <xsl:if test="$rules[@method='document']|$external-includes">
                 <xsl:choose>
                     <xsl:when test="$usebase">
                         <!-- When usebase is true, document() includes are resolved internally using the base tag -->

--- a/lib/diazo/normalize-rules.xsl
+++ b/lib/diazo/normalize-rules.xsl
@@ -31,6 +31,9 @@
     <xsl:template match="/diazo:rules">
         <xsl:element name="diazo:{local-name()}">
             <xsl:attribute name="css:dummy"/>
+            <xsl:if test=".//diazo:include[@href]">
+                <xsl:attribute name="external-includes">1</xsl:attribute>
+            </xsl:if>
             <xsl:apply-templates select="@*|node()"/>
         </xsl:element>
     </xsl:template>
@@ -129,6 +132,24 @@
             </xsl:call-template>
         </xsl:if>
         <xsl:attribute name="mode">raw</xsl:attribute>
+    </xsl:template>
+
+    <xsl:template match="//diazo:include">
+        <xsl:element name="xsl:apply-templates">
+            <xsl:if test="@href">
+                <xsl:attribute name="method">document</xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="select">
+                <xsl:choose>
+                    <xsl:when test="@href">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="@content"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+            <xsl:attribute name="mode">raw</xsl:attribute>
+        </xsl:element>
     </xsl:template>
 
     <!--

--- a/lib/diazo/normalize-rules.xsl
+++ b/lib/diazo/normalize-rules.xsl
@@ -31,7 +31,7 @@
     <xsl:template match="/diazo:rules">
         <xsl:element name="diazo:{local-name()}">
             <xsl:attribute name="css:dummy"/>
-            <xsl:if test=".//diazo:include[@href]">
+            <xsl:if test=".//diazo:*[@href]">
                 <xsl:attribute name="external-includes">1</xsl:attribute>
             </xsl:if>
             <xsl:apply-templates select="@*|node()"/>
@@ -44,7 +44,7 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="//diazo:rules/diazo:before[@theme-children]">
+    <xsl:template match="//diazo:rules/diazo:before[@theme-children][* or (@method and @method!='document')]">
         <xsl:element name="diazo:prepend">
             <xsl:if test="@href and not(@method)">
                 <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
@@ -58,7 +58,29 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="//diazo:rules/diazo:after[@theme-children]">
+    <xsl:template match="//diazo:rules/diazo:before[@theme-children][not(*) and (not(@method) or @method='document')]">
+        <xsl:variable name="content">
+            <xsl:choose>
+                <xsl:when test="@content-children">
+                    <xsl:value-of select="@content-children"/>/node()
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="@content"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:element name="diazo:prepend">
+            <xsl:apply-templates select="@*[local-name()!='content' and local-name()!='href' and local-name()!='method']"/>
+            <xsl:attribute name="theme"><xsl:value-of select="@theme-children"/></xsl:attribute>
+            <xsl:call-template name="include">
+                <xsl:with-param name="content" select="$content"/>
+                <xsl:with-param name="href" select="@href"/>
+                <xsl:with-param name="method" select="@method"/>
+            </xsl:call-template>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:rules/diazo:after[@theme-children][* or (@method and @method!='document')]">
         <xsl:element name="diazo:append">
             <xsl:if test="@href and not(@method)">
                 <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
@@ -72,7 +94,40 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="//diazo:rules/diazo:replace[@theme-children]|//diazo:rules/diazo:drop[@theme-children]">
+    <xsl:template match="//diazo:rules/diazo:after[@theme-children][not(*) and (not(@method) or @method='document')]">
+        <xsl:variable name="content">
+            <xsl:choose>
+                <xsl:when test="@content-children">
+                    <xsl:value-of select="@content-children"/>/node()
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="@content"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:element name="diazo:append">
+            <xsl:apply-templates select="@*[local-name()!='content' and local-name()!='href' and local-name()!='method']"/>
+            <xsl:attribute name="theme"><xsl:value-of select="@theme-children"/></xsl:attribute>
+            <xsl:call-template name="include">
+                <xsl:with-param name="content" select="$content"/>
+                <xsl:with-param name="href" select="@href"/>
+                <xsl:with-param name="method" select="@method"/>
+            </xsl:call-template>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:rules/diazo:*[local-name()='before' or local-name()='after'][@content][not(@theme-children)][not(*) and (not(@method) or @method='document')]">
+        <xsl:element name="diazo:{local-name()}">
+            <xsl:apply-templates select="@*[local-name()!='content' and local-name()!='href' and local-name()!='method']"/>
+            <xsl:call-template name="include">
+                <xsl:with-param name="content" select="@content"/>
+                <xsl:with-param name="href" select="@href"/>
+                <xsl:with-param name="method" select="@method"/>
+            </xsl:call-template>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:rules/diazo:replace[@theme-children][* or (@method and @method!='document')]|//diazo:rules/diazo:drop[@theme-children]">
         <xsl:element name="diazo:copy">
             <xsl:if test="@href and not(@method)">
                 <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
@@ -83,6 +138,28 @@
                 <xsl:attribute name="content"><xsl:value-of select="@content-children"/>/node()</xsl:attribute>
             </xsl:if>
             <xsl:apply-templates select="node()"/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:rules/diazo:replace[@theme-children][not(*) and (not(@method) or @method='document')]">
+        <xsl:variable name="content">
+            <xsl:choose>
+                <xsl:when test="@content-children">
+                    <xsl:value-of select="@content-children"/>/node()
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="@content"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:element name="diazo:copy">
+            <xsl:apply-templates select="@*[local-name()!='content' and local-name()!='href' and local-name()!='method']"/>
+            <xsl:attribute name="theme"><xsl:value-of select="@theme-children"/></xsl:attribute>            
+            <xsl:call-template name="include">
+                <xsl:with-param name="content" select="$content"/>
+                <xsl:with-param name="href" select="@href"/>
+                <xsl:with-param name="method" select="@method"/>
+            </xsl:call-template>
         </xsl:element>
     </xsl:template>
 
@@ -134,22 +211,36 @@
         <xsl:attribute name="mode">raw</xsl:attribute>
     </xsl:template>
 
-    <xsl:template match="//diazo:include">
+    <xsl:template name="include">
+        <xsl:param name="content"/>
+        <xsl:param name="href"/>
+        <xsl:param name="mode"/>
         <xsl:element name="xsl:apply-templates">
-            <xsl:if test="@href">
-                <xsl:attribute name="method">document</xsl:attribute>
+            <xsl:if test="$href">
+                <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
             </xsl:if>
             <xsl:attribute name="select">
                 <xsl:choose>
-                    <xsl:when test="@href">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/>
+                    <xsl:when test="$href">document('<xsl:value-of select="$href"/>', $diazo-base-document)<xsl:if test="not(starts-with($content, '/'))">/</xsl:if><xsl:value-of select="$content"/>
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:value-of select="@content"/>
+                        <xsl:value-of select="$content"/>
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:attribute>
-            <xsl:attribute name="mode">raw</xsl:attribute>
+            <xsl:if test="$mode">
+                <xsl:attribute name="mode"><xsl:value-of select="$mode"/></xsl:attribute>
+            </xsl:if>
         </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:include">
+        <xsl:call-template name="include">
+            <xsl:with-param name="content" select="@content"/>
+            <xsl:with-param name="href" select="@href"/>
+            <xsl:with-param name="method" select="@method"/>
+            <xsl:with-param name="mode">raw</xsl:with-param>
+        </xsl:call-template>
     </xsl:template>
 
     <!--

--- a/lib/diazo/tests/include-content/content.html
+++ b/lib/diazo/tests/include-content/content.html
@@ -1,0 +1,14 @@
+<html>
+  <body>
+      <div id="breadcrumbs">
+          <span id="you-are-here">You are here</span>
+      </div>
+      <span id="date">2015-04-02</span>
+      <div id="source-content">
+          <article>
+              <h1>Title</h1>
+              <section>Description</section>
+          </article>
+      </div>
+  </body>
+</html>

--- a/lib/diazo/tests/include-content/extra.html
+++ b/lib/diazo/tests/include-content/extra.html
@@ -1,0 +1,6 @@
+<div id="related">
+    Document 2
+</div>
+<div id="portlet">
+    Portlet
+</div>

--- a/lib/diazo/tests/include-content/output.html
+++ b/lib/diazo/tests/include-content/output.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div id="source-content">
+      <div id="breadcrumbs">
+        <span id="you-are-here">You are here</span>
+      </div>
+      <article>
+        <h1>Title</h1>
+        <span id="date">2015-04-02</span>
+        <section>Description</section>
+        <div id="related">
+          Document 2
+        </div>
+      </article>
+    </div>
+    <div id="portlet">
+      Portlet
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/include-content/rules.xml
+++ b/lib/diazo/tests/include-content/rules.xml
@@ -1,0 +1,28 @@
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    >
+
+    <before css:content-children="#source-content">
+        <include css:content="#breadcrumbs" />
+    </before>
+
+    <after css:content="h1">
+        <include css:content="#date" />
+    </after>
+
+    <replace css:theme="#footer">
+        <include css:content="#portlet" href="extra.html" />
+    </replace>
+
+    <after css:content="section">
+        <include css:content="#related" href="extra.html" />
+    </after>
+    
+    <replace
+        css:theme="#target-content"
+        css:content="#source-content"
+        />
+
+</rules>

--- a/lib/diazo/tests/include-content/theme.html
+++ b/lib/diazo/tests/include-content/theme.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <div id="target-content"></div>
+  <div id="footer"></div>
+</body>
+</html>


### PR DESCRIPTION
This PR is #44 rebased and improved.
@lrowe, according our discussion in #44, I have extended the `<include>` directive mechanism to other directives having `css:content` attributes, so now:
```
<before css:theme-children="#main" css:content="#breadcrumbs" />
```
is equivalent to:
```
<before css:theme-children="#main">
    <include css:content="#breadcrumbs" />
</before>
```
It does work fine, but:
- the only case I haven't been able to process is `<replace theme=...>` (it does work with `<replace theme-children=...>` though), so in that very case, we still use the original approach to insert the content.
- SSI/ESI is still processed as it used to be.

I let you have a look, and if you have no major doubt about this implementation, I think we will merge this PR as it really improves the Plone theming user story.