### PR TITLE
Include content refactor

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -266,7 +266,21 @@ For example::
         <a href="mailto:contact@diazo.org">Ask for help</a>
     </before>
 
-This may be combined with conditions and inline XSLT.
+The content can be inline HTML or it can be a piece of content from the document
+itself retrieved using the ``<include />`` tag. For instance::
+
+    <before css:content-children="#main">
+        <include css:content="#breadcrumbs" />
+    </before>
+
+The ``<include />`` tag accepts a ``href`` attribute, so it can retrieve a piece
+of content from another page. For instance::
+
+    <after css:content="#main">
+        <include css:content="form" href="contact.html" />
+    </after>
+
+This may also be combined with conditions and inline XSLT.
 
 Warning: it is not possible to both modify the content children and put them in
 the theme, for instance::

--- a/lib/diazo/annotate-rules.xsl
+++ b/lib/diazo/annotate-rules.xsl
@@ -9,36 +9,7 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     >
 
-    <xsl:param name="ssiprefix"></xsl:param>
-    <xsl:param name="ssisuffix"></xsl:param>
-    <xsl:param name="ssiquerysuffix">;filter_xpath=</xsl:param>
-    <xsl:param name="esiprefix"></xsl:param>
-    <xsl:param name="esisuffix"></xsl:param>
-    <xsl:param name="esiquerysuffix">;filter_xpath=</xsl:param>
-
     <xsl:template match="@*|node()">
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-        </xsl:copy>
-    </xsl:template>
-
-    <xsl:template match="diazo:drop[@content]">
-        <xsl:if test="@theme">
-            <xsl:call-template name="error-message" select=".">
-                <xsl:with-param name="message">@theme and @content attributes not allowed in same drop rule</xsl:with-param>
-            </xsl:call-template>
-        </xsl:if>
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-        </xsl:copy>
-    </xsl:template>
-
-    <xsl:template match="diazo:strip[@content]">
-        <xsl:if test="@theme">
-            <xsl:call-template name="error-message" select=".">
-                <xsl:with-param name="message">@theme and @content attributes not allowed in same strip rule</xsl:with-param>
-            </xsl:call-template>
-        </xsl:if>
         <xsl:copy>
             <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
@@ -47,29 +18,9 @@
     <xsl:template match="diazo:*[@theme]">
         <xsl:copy>
             <xsl:apply-templates select="@*"/>
-                <xsl:choose>
-                    <xsl:when test="node()">
-                        <xsl:if test="@content">
-                            <xsl:call-template name="error-message" select=".">
-                                <xsl:with-param name="message">@content attribute and inline content not allowed in same rule</xsl:with-param>
-                            </xsl:call-template>
-                        </xsl:if>
-                        <xsl:if test="@href">
-                            <xsl:call-template name="error-message" select=".">
-                                <xsl:with-param name="message">@href attribute and inline content not allowed in same rule</xsl:with-param>
-                            </xsl:call-template>
-                        </xsl:if>
-                        <diazo:synthetic>
-                            <xsl:copy-of select="node()"/>
-                        </diazo:synthetic>
-                    </xsl:when>
-                    <xsl:when test="@action='drop-theme-children'">
-                        <diazo:synthetic/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:apply-templates select="." mode="include"/>
-                    </xsl:otherwise>
-                </xsl:choose>
+                <diazo:synthetic>
+                    <xsl:copy-of select="node()"/>
+                </diazo:synthetic>
             <diazo:matches>
                 <xsl:variable name="themexpath" select="@theme"/>
                 <xsl:for-each select="//diazo:theme">
@@ -97,86 +48,6 @@
                 <xsl:value-of select="@xml:id"/>
             </diazo:xmlid>
         </xsl:for-each>
-    </xsl:template>
-
-    <xsl:template match="*[not(@href)]" mode="include" priority="5">
-      <diazo:synthetic>
-        <xsl:element name="xsl:apply-templates">
-            <xsl:attribute name="select">
-                <xsl:value-of select="@content"/>
-            </xsl:attribute>
-            <xsl:if test="@mode">
-                <xsl:attribute name="mode"><xsl:value-of select="@mode"/></xsl:attribute>
-            </xsl:if>
-        </xsl:element>
-      </diazo:synthetic>
-    </xsl:template>
-
-    <xsl:template match="*[@method = 'document']" mode="include">
-      <diazo:synthetic>
-        <xsl:element name="xsl:apply-templates">
-            <xsl:attribute name="select">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/></xsl:attribute>
-            <xsl:choose>
-                <xsl:when test="@mode">
-                    <xsl:attribute name="mode"><xsl:value-of select="@mode"/></xsl:attribute>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:attribute name="mode">raw</xsl:attribute>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:element>
-      </diazo:synthetic>
-    </xsl:template>
-
-    <xsl:template match="*[@method = 'transform']" mode="include">
-      <diazo:synthetic>
-        <xsl:element name="xsl:apply-templates">
-            <xsl:attribute name="select">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/></xsl:attribute>
-        </xsl:element>
-      </diazo:synthetic>
-    </xsl:template>
-
-    <xsl:template match="*[@method = 'ssi' or @method = 'ssiwait']" mode="include">
-        <!-- Assumptions:
-            * When using ssiprefix, @href should be an absolute local path (i.e.  /foo/bar)
-        -->
-      <diazo:synthetic>
-        <xsl:variable name="content_quoted" select="str:encode-uri(@content, false())"/>
-        <xsl:element name="xsl:comment">#include  virtual="<xsl:value-of select="$ssiprefix"/><xsl:choose>
-            <xsl:when test="not(@content)"><xsl:value-of select="@href"/></xsl:when>
-            <xsl:when test="contains(@href, '?')"><xsl:value-of select="concat(str:replace(@href, '?', concat($ssisuffix, '?')), $ssiquerysuffix, $content_quoted)"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="concat(@href, $ssisuffix, '?', $ssiquerysuffix, $content_quoted)"/></xsl:otherwise>
-            </xsl:choose>"<xsl:if test="@method = 'ssiwait'"> wait="yes"</xsl:if></xsl:element>
-      </diazo:synthetic>
-    </xsl:template>
-
-    <xsl:template match="*[@method = 'esi']" mode="include">
-        <!-- Assumptions:
-            * When using esiprefix, @href should be an absolute local path (i.e.  /foo/bar)
-        -->
-      <diazo:synthetic>
-        <xsl:variable name="content_quoted" select="str:encode-uri(@content, false())"/>
-        <esi:include><xsl:attribute name="src"><xsl:choose>
-            <xsl:when test="not(@content)"><xsl:value-of select="@href"/></xsl:when>
-            <xsl:when test="contains(@href, '?')"><xsl:value-of select="concat(str:replace(@href, '?', concat($esisuffix, '?')), $esiquerysuffix, $content_quoted)"/></xsl:when>
-            <xsl:otherwise><xsl:value-of select="concat(@href, $esisuffix, '?', $esiquerysuffix, $content_quoted)"/></xsl:otherwise>
-            </xsl:choose></xsl:attribute></esi:include>
-      </diazo:synthetic>
-    </xsl:template>
-
-    <xsl:template match="diazo:attributes[@href]" mode="include">
-        <xsl:if test="@method != 'document'">
-            <xsl:call-template name="error-message" select=".">
-                <xsl:with-param name="message">Attributes may only be included from external documents with 'document' include mode.</xsl:with-param>
-            </xsl:call-template>
-        </xsl:if>
-        <xsl:attribute name="content">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/></xsl:attribute>
-    </xsl:template>
-
-    <xsl:template match="*" mode="include">
-        <xsl:call-template name="error-message" select=".">
-            <xsl:with-param name="message">Unknown includemode or @method attribute</xsl:with-param>
-        </xsl:call-template>
     </xsl:template>
 
     <!--

--- a/lib/diazo/emit-stylesheet.xsl
+++ b/lib/diazo/emit-stylesheet.xsl
@@ -18,6 +18,7 @@
     <xsl:param name="runtrace">0</xsl:param>
 
     <xsl:variable name="rules" select="//dv:*[@theme]"/>
+    <xsl:variable name="usedocument" select="boolean(//xsl:*[@select and contains(@select, 'document(')])"/>
     <xsl:variable name="drop-content-rules" select="//dv:drop[@content]"/>
     <xsl:variable name="strip-content-rules" select="//dv:strip[@content]"/>
     <xsl:variable name="before-replace-after-content-selectors" select="//dv:*[local-name()='before' or local-name()='replace' or local-name()='after'][@content and not(@theme) and not(@content-children)]/@content|//dv:*[local-name()='before' or local-name()='replace' or local-name()='after'][@content and not(@theme) and @content-children]/@content-children"/>
@@ -62,7 +63,7 @@
             <xsl:text>&#10;&#10;</xsl:text>
             <xsl:apply-templates select="document($known_params_url)/xsl:stylesheet/node()" />
 
-            <xsl:if test="$rules[@method='document']">
+            <xsl:if test="$usedocument">
                 <xsl:choose>
                     <xsl:when test="$usebase">
                         <!-- When usebase is true, document() includes are resolved internally using the base tag -->

--- a/lib/diazo/include.xsl
+++ b/lib/diazo/include.xsl
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:diazo="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:esi="http://www.edge-delivery.org/esi/1.0"
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    xmlns:str="http://exslt.org/strings"
+    >
+
+    <xsl:param name="ssiprefix"></xsl:param>
+    <xsl:param name="ssisuffix"></xsl:param>
+    <xsl:param name="ssiquerysuffix">;filter_xpath=</xsl:param>
+    <xsl:param name="esiprefix"></xsl:param>
+    <xsl:param name="esisuffix"></xsl:param>
+    <xsl:param name="esiquerysuffix">;filter_xpath=</xsl:param>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="diazo:include">
+        <xsl:choose>
+            <xsl:when test="@condition">
+                <xsl:element name="xsl:if">
+                    <xsl:attribute name="test">
+                        <xsl:value-of select="@condition"/>
+                    </xsl:attribute>
+                    <xsl:apply-templates mode="include" select="."/>
+                </xsl:element>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates mode="include" select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="diazo:include[not(@href)]" priority="5" mode="include">
+        <xsl:element name="xsl:apply-templates">
+            <xsl:attribute name="select">
+                <xsl:value-of select="@content"/>
+            </xsl:attribute>
+            <xsl:if test="@mode">
+                <xsl:attribute name="mode"><xsl:value-of select="@mode"/></xsl:attribute>
+            </xsl:if>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="diazo:include[@method = 'document']" mode="include">
+        <xsl:element name="xsl:apply-templates">
+            <xsl:attribute name="select">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/></xsl:attribute>
+            <xsl:choose>
+                <xsl:when test="@mode">
+                    <xsl:attribute name="mode"><xsl:value-of select="@mode"/></xsl:attribute>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:attribute name="mode">raw</xsl:attribute>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="diazo:include[@method = 'transform']" mode="include">
+        <xsl:element name="xsl:apply-templates">
+            <xsl:attribute name="select">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/></xsl:attribute>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="diazo:include[@method = 'ssi' or @method = 'ssiwait']" mode="include">
+        <!-- Assumptions:
+            * When using ssiprefix, @href should be an absolute local path (i.e.  /foo/bar)
+        -->
+        <xsl:variable name="content_quoted" select="str:encode-uri(@content, false())"/>
+        <xsl:element name="xsl:comment">#include  virtual="<xsl:value-of select="$ssiprefix"/><xsl:choose>
+            <xsl:when test="not(@content)"><xsl:value-of select="@href"/></xsl:when>
+            <xsl:when test="contains(@href, '?')"><xsl:value-of select="concat(str:replace(@href, '?', concat($ssisuffix, '?')), $ssiquerysuffix, $content_quoted)"/></xsl:when>
+            <xsl:otherwise><xsl:value-of select="concat(@href, $ssisuffix, '?', $ssiquerysuffix, $content_quoted)"/></xsl:otherwise>
+            </xsl:choose>"<xsl:if test="@method = 'ssiwait'"> wait="yes"</xsl:if></xsl:element>
+    </xsl:template>
+
+    <xsl:template match="diazo:include[@method = 'esi']" mode="include">
+        <!-- Assumptions:
+            * When using esiprefix, @href should be an absolute local path (i.e.  /foo/bar)
+        -->
+        <xsl:variable name="content_quoted" select="str:encode-uri(@content, false())"/>
+        <esi:include><xsl:attribute name="src"><xsl:choose>
+            <xsl:when test="not(@content)"><xsl:value-of select="@href"/></xsl:when>
+            <xsl:when test="contains(@href, '?')"><xsl:value-of select="concat(str:replace(@href, '?', concat($esisuffix, '?')), $esiquerysuffix, $content_quoted)"/></xsl:when>
+            <xsl:otherwise><xsl:value-of select="concat(@href, $esisuffix, '?', $esiquerysuffix, $content_quoted)"/></xsl:otherwise>
+            </xsl:choose></xsl:attribute></esi:include>
+    </xsl:template>
+
+    <xsl:template match="diazo:include" priority="-1" mode="include">
+        <xsl:call-template name="error-message" select=".">
+            <xsl:with-param name="message">Unknown includemode or @method attribute</xsl:with-param>
+        </xsl:call-template>
+    </xsl:template>
+
+
+    <!--
+        Debugging support
+    -->
+
+    <xsl:template name="error-message">
+        <xsl:param name="message"/>
+        <xsl:message terminate="yes">ERROR: <xsl:value-of select="$message"/>&#10;    RULE: &lt;<xsl:value-of select="name()"/><xsl:for-each select="@*">
+            <xsl:value-of select="' '"/><xsl:value-of select="name()"/>="<xsl:value-of select="."/>"</xsl:for-each>/&gt;
+        </xsl:message>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/lib/diazo/normalize-rules.xsl
+++ b/lib/diazo/normalize-rules.xsl
@@ -15,16 +15,80 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="diazo:rules | //diazo:rules/diazo:*">
+    <xsl:template match="//diazo:rules/diazo:rules | //diazo:rules/diazo:theme">
         <xsl:element name="diazo:{local-name()}">
-            <xsl:if test="@href and not(@method) and local-name() != 'theme'">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:include">
+        <xsl:element name="diazo:{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="@href and not(@method)">
                 <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
             </xsl:if>
-            <xsl:apply-templates select="@*"/>
-            <xsl:if test="@content-children and not(local-name() = 'replace' and not(@theme))">
+            <xsl:if test="@content-children">
                 <xsl:attribute name="content"><xsl:value-of select="@content-children"/>/node()</xsl:attribute>
             </xsl:if>
+            <xsl:if test="@method = 'raw'">
+                <xsl:if test="@mode">
+                    <xsl:call-template name="error-message" select="..">
+                        <xsl:with-param name="message">@mode and @method="raw" not allowed in same rule.</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:if>
+                <xsl:attribute name="mode">raw</xsl:attribute>
+            </xsl:if>
             <xsl:apply-templates select="node()"/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:rules/diazo:replace[not(@theme) and not(@theme-children)]">
+        <xsl:element name="diazo:{local-name()}">
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:rules/diazo:*[not(@theme) and not(@theme-children)]">
+        <xsl:element name="diazo:{local-name()}">
+            <xsl:if test="@content-children">
+                <xsl:attribute name="content"><xsl:value-of select="@content-children"/>/node()</xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="//diazo:rules/diazo:*[@theme]">
+        <xsl:element name="diazo:{local-name()}">
+            <xsl:apply-templates select="@*"/>
+            <xsl:choose>
+                <xsl:when test="@content or @content-children or @href">
+                    <xsl:if test="node()">
+                        <xsl:call-template name="error-message" select=".">
+                            <xsl:with-param name="message">inline content not allowed in same rule as @content/@content-children/@href</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:if>
+                    <xsl:element name="diazo:include">
+                        <xsl:apply-templates select="@content|@href|@mode|@method"/>
+                        <xsl:if test="@href and not(@method)">
+                            <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
+                        </xsl:if>
+                        <xsl:if test="@content-children">
+                            <xsl:attribute name="content"><xsl:value-of select="@content-children"/>/node()</xsl:attribute>
+                        </xsl:if>
+                        <xsl:if test="@method = 'raw'">
+                            <xsl:if test="@mode">
+                                <xsl:call-template name="error-message" select="..">
+                                    <xsl:with-param name="message">@mode and @method="raw" not allowed in same rule.</xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:if>
+                            <xsl:attribute name="mode">raw</xsl:attribute>
+                        </xsl:if>
+                    </xsl:element>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="node()"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:element>
     </xsl:template>
 
@@ -41,45 +105,51 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="//diazo:rules/diazo:before[@theme-children]">
-        <xsl:element name="diazo:prepend">
-            <xsl:if test="@href and not(@method)">
-                <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
-            </xsl:if>
+    <xsl:template match="//diazo:rules/diazo:*[@theme-children]">
+        <xsl:variable name="elem-name">
+            <xsl:choose>
+                <xsl:when test="local-name() = 'before'">prepend</xsl:when>
+                <xsl:when test="local-name() = 'after'">append</xsl:when>
+                <xsl:when test="local-name() = 'replace'">copy</xsl:when>
+                <xsl:otherwise>
+                    <xsl:call-template name="error-message" select=".">
+                        <xsl:with-param name="message">@theme-children not allowed here</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:element name="diazo:{$elem-name}">
             <xsl:apply-templates select="@*"/>
             <xsl:attribute name="theme"><xsl:value-of select="@theme-children"/></xsl:attribute>
-            <xsl:if test="@content-children">
-                <xsl:attribute name="content"><xsl:value-of select="@content-children"/>/node()</xsl:attribute>
-            </xsl:if>
-            <xsl:apply-templates select="node()"/>
-        </xsl:element>
-    </xsl:template>
-
-    <xsl:template match="//diazo:rules/diazo:after[@theme-children]">
-        <xsl:element name="diazo:append">
-            <xsl:if test="@href and not(@method)">
-                <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
-            </xsl:if>
-            <xsl:apply-templates select="@*"/>
-            <xsl:attribute name="theme"><xsl:value-of select="@theme-children"/></xsl:attribute>
-            <xsl:if test="@content-children">
-                <xsl:attribute name="content"><xsl:value-of select="@content-children"/>/node()</xsl:attribute>
-            </xsl:if>
-            <xsl:apply-templates select="node()"/>
-        </xsl:element>
-    </xsl:template>
-
-    <xsl:template match="//diazo:rules/diazo:replace[@theme-children]|//diazo:rules/diazo:drop[@theme-children]">
-        <xsl:element name="diazo:copy">
-            <xsl:if test="@href and not(@method)">
-                <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
-            </xsl:if>
-            <xsl:apply-templates select="@*"/>
-            <xsl:attribute name="theme"><xsl:value-of select="@theme-children"/></xsl:attribute>
-            <xsl:if test="@content-children">
-                <xsl:attribute name="content"><xsl:value-of select="@content-children"/>/node()</xsl:attribute>
-            </xsl:if>
-            <xsl:apply-templates select="node()"/>
+            <xsl:choose>
+                <xsl:when test="@content or @content-children or @href">
+                    <xsl:if test="node()">
+                        <xsl:call-template name="error-message" select=".">
+                            <xsl:with-param name="message">inline content not allowed in same rule as @content/@content-children/@href</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:if>
+                    <xsl:element name="diazo:include">
+                        <xsl:apply-templates select="@content|@href|@mode|@method"/>
+                        <xsl:if test="@href and not(@method)">
+                            <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
+                        </xsl:if>
+                        <xsl:if test="@content-children">
+                            <xsl:attribute name="content"><xsl:value-of select="@content-children"/>/node()</xsl:attribute>
+                        </xsl:if>
+                        <xsl:if test="@method = 'raw'">
+                            <xsl:if test="@mode">
+                                <xsl:call-template name="error-message" select="..">
+                                    <xsl:with-param name="message">@mode and @method="raw" not allowed in same rule.</xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:if>
+                            <xsl:attribute name="mode">raw</xsl:attribute>
+                        </xsl:if>
+                    </xsl:element>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="node()"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:element>
     </xsl:template>
 
@@ -97,10 +167,15 @@
             <xsl:attribute name="action"><xsl:value-of select="local-name()"/></xsl:attribute>
             <xsl:attribute name="attributes"><xsl:value-of select="concat(' ', normalize-space(@attributes), ' ')"/></xsl:attribute>
             <xsl:if test="local-name() = 'merge' and not(@separator)">
-              <xsl:attribute name="separator"><xsl:text> </xsl:text></xsl:attribute>
+                <xsl:attribute name="separator"><xsl:text> </xsl:text></xsl:attribute>
             </xsl:if>
-            <xsl:if test="@href and not(@method)">
-                <xsl:attribute name="method"><xsl:value-of select="$includemode"/></xsl:attribute>
+            <xsl:if test="@href">
+                <xsl:if test="(not(@method) and $includemode != 'document') or @method != 'document'">
+                    <xsl:call-template name="error-message" select=".">
+                        <xsl:with-param name="message">Attributes may only be included from external documents with 'document' include mode.</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:if>
+                <xsl:attribute name="content">document('<xsl:value-of select="@href"/>', $diazo-base-document)<xsl:if test="not(starts-with(@content, '/'))">/</xsl:if><xsl:value-of select="@content"/></xsl:attribute>
             </xsl:if>
             <xsl:apply-templates select="node()"/>
         </xsl:element>
@@ -122,13 +197,10 @@
         </xsl:for-each>
     </xsl:template>
 
-    <xsl:template match="//diazo:rules/diazo:*[not(@href) and @method = 'raw']/@method">
-        <xsl:if test="../@mode">
-            <xsl:call-template name="error-message" select="..">
-                <xsl:with-param name="message">@mode and @method="raw" not allowed in same rule.</xsl:with-param>
-            </xsl:call-template>
-        </xsl:if>
-        <xsl:attribute name="mode">raw</xsl:attribute>
+    <xsl:template match="diazo:drop[(@content or @content-children) and (@theme or @theme-children)] | diazo:strip[(@content or @content-children) and (@theme or @theme-children)]" priority="10">
+        <xsl:call-template name="error-message" select=".">
+            <xsl:with-param name="message">@theme and @content attributes not allowed in same <xsl:value-of select="local-name()"/> rule</xsl:with-param>
+        </xsl:call-template>
     </xsl:template>
 
     <!--

--- a/lib/diazo/rules.py
+++ b/lib/diazo/rules.py
@@ -28,6 +28,7 @@ SRCSET = re.compile(r'(?P<descriptors>^\s*|\s*,\s*)(?P<url>[^\s]*)')
 
 update_transform = pkg_xsl('update-namespace.xsl')
 normalize_rules = pkg_xsl('normalize-rules.xsl')
+include = pkg_xsl('include.xsl')
 apply_conditions = pkg_xsl('apply-conditions.xsl')
 merge_conditions = pkg_xsl('merge-conditions.xsl')
 annotate_themes = pkg_xsl('annotate-themes.xsl')
@@ -264,8 +265,11 @@ def process_rules(rules, theme=None, extra=None, trace=None, css=True,
     rules_doc = annotate_themes(rules_doc)
     if stop == 11:
         return rules_doc
-    rules_doc = annotate_rules(rules_doc)
+    rules_doc = include(rules_doc)
     if stop == 12:
+        return rules_doc
+    rules_doc = annotate_rules(rules_doc)
+    if stop == 13:
         return rules_doc
     rules_doc = apply_rules(rules_doc, trace=trace)
     return rules_doc

--- a/lib/diazo/tests/conditional-include-content/content.html
+++ b/lib/diazo/tests/conditional-include-content/content.html
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <div id="target"></div>  
+    <div id="source">
+      <div id="a">a</div>
+      <div id="b">b</div>
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/conditional-include-content/output.html
+++ b/lib/diazo/tests/conditional-include-content/output.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div id="target">
+      <div id="a">a</div>
+    </div>  
+  </body>
+</html>

--- a/lib/diazo/tests/conditional-include-content/rules.xml
+++ b/lib/diazo/tests/conditional-include-content/rules.xml
@@ -1,0 +1,15 @@
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    >
+
+    <replace css:theme="body" css:content="body"/>
+
+    <before css:content-children="#target">
+        <include css:content="#a" if="true()"/>
+        <include css:content="#b" if="false()"/>
+    </before>
+
+    <drop css:content="#source"/>
+
+</rules>

--- a/lib/diazo/tests/conditional-include-content/theme.html
+++ b/lib/diazo/tests/conditional-include-content/theme.html
@@ -1,0 +1,4 @@
+<html>
+<body>
+</body>
+</html>

--- a/lib/diazo/tests/include-content/content.html
+++ b/lib/diazo/tests/include-content/content.html
@@ -1,0 +1,14 @@
+<html>
+  <body>
+      <div id="breadcrumbs">
+          <span id="you-are-here">You are here</span>
+      </div>
+      <span id="date">2015-04-02</span>
+      <div id="source-content">
+          <article>
+              <h1>Title</h1>
+              <section>Description</section>
+          </article>
+      </div>
+  </body>
+</html>

--- a/lib/diazo/tests/include-content/extra.html
+++ b/lib/diazo/tests/include-content/extra.html
@@ -1,0 +1,6 @@
+<div id="related">
+    Document 2
+</div>
+<div id="portlet">
+    Portlet
+</div>

--- a/lib/diazo/tests/include-content/output.html
+++ b/lib/diazo/tests/include-content/output.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div id="source-content">
+      <div id="breadcrumbs">
+        <span id="you-are-here">You are here</span>
+      </div>
+      <article>
+        <h1>Title</h1>
+        <span id="date">2015-04-02</span>
+        <section>Description</section>
+        <div id="related">
+          Document 2
+        </div>
+      </article>
+    </div>
+    <div id="portlet">
+      Portlet
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/include-content/rules.xml
+++ b/lib/diazo/tests/include-content/rules.xml
@@ -1,0 +1,28 @@
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    >
+
+    <before css:content-children="#source-content">
+        <include css:content="#breadcrumbs" />
+    </before>
+
+    <after css:content="h1">
+        <include css:content="#date" />
+    </after>
+
+    <replace css:theme="#footer">
+        <include css:content="#portlet" href="extra.html" />
+    </replace>
+
+    <after css:content="section">
+        <include css:content="#related" href="extra.html" />
+    </after>
+    
+    <replace
+        css:theme="#target-content"
+        css:content="#source-content"
+        />
+
+</rules>

--- a/lib/diazo/tests/include-content/theme.html
+++ b/lib/diazo/tests/include-content/theme.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <div id="target-content"></div>
+  <div id="footer"></div>
+</body>
+</html>


### PR DESCRIPTION
This takes a different approach to implementing #49 in that it first normalizes the rule:
```
<before css:theme-children="#main" css:content="#breadcrumbs" />
```
to:
```
<before css:theme-children="#main">
    <include css:content="#breadcrumbs" />
</before>
```
so that we ensure consistency between the alternatives.