### PR TITLE
Add absolute url prefix to xlink:href attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 New:
 
 - *add item here*
+- Add absolute url prefix to xlink:href attributes
+  [krissik]
 
 Fixes:
 

--- a/lib/diazo/rules.py
+++ b/lib/diazo/rules.py
@@ -140,6 +140,10 @@ def apply_absolute_prefix(theme_doc, absolute_prefix):
     for node in theme_doc.xpath('//*[@src]'):
         url = urljoin(absolute_prefix, node.get('src'))
         node.set('src', url)
+    for xlink_attr in theme_doc.xpath('//@*[local-name()="xlink:href"]'):
+        node = xlink_attr.getparent()
+        url = urljoin(absolute_prefix, node.get('xlink:href'))
+        node.set('xlink:href', url)
     for node in theme_doc.xpath('//*[@srcset]'):
         srcset = node.get('srcset')
         srcset = SRCSET.sub(

--- a/lib/diazo/tests/absolute-prefix/output.html
+++ b/lib/diazo/tests/absolute-prefix/output.html
@@ -39,5 +39,9 @@
     <input type="submit" src="http://site.com/foo.jpg" />
     <a href="/abs/foo.html">Link</a>
     <a href="#foo">Anchor</a>
+    <div xmlns:xlink="http://www.w3.org/1999/xlink">
+      <svg><use xlink:href="/abs/img/foo.svg"></use></svg>
+      <span xlink:href="/abs/foo.html"></span>
+    </div>
   </body>
 </html>

--- a/lib/diazo/tests/absolute-prefix/theme.html
+++ b/lib/diazo/tests/absolute-prefix/theme.html
@@ -39,5 +39,9 @@
     <input type="submit" src="http://site.com/foo.jpg" />
     <a href="foo.html">Link</a>
     <a href="#foo">Anchor</a>
+    <div xmlns:xlink="http://www.w3.org/1999/xlink">
+      <svg><use xlink:href="img/foo.svg"></use></svg>
+      <span xlink:href="foo.html"></span>
+    </div>
   </body>
 </html>

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,5 +5,5 @@ versions = versions
 WebOb = 1.4
 cssselect = 0.9.1
 lxml = 3.3.5
-repoze.xmliter = 0.5
+repoze.xmliter = 0.6
 FormEncode = 1.3.0a1


### PR DESCRIPTION
Hi,
we use svg in our theme that looks like that:
`<svg><use xlink:href="img/icons.svg#home"/></svg>`

and we need them to be prefixed with absolute url like other images.

