### PR TITLE
[test] Broken rules when mixing CSS and xpath rules

### DIFF
--- a/lib/diazo/tests/css-css-same-element/content.html
+++ b/lib/diazo/tests/css-css-same-element/content.html
@@ -1,0 +1,10 @@
+<html>
+  <body class="front-page">
+    <div class="content">
+      <p class="placeholder"><!-- nothing --></p>
+      <div class="wrapper">
+        <p class="actual-content">my text here</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/css-css-same-element/output.html
+++ b/lib/diazo/tests/css-css-same-element/output.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div class="content">
+      <p class="actual-content">my text here</p>
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/css-css-same-element/rules.xml
+++ b/lib/diazo/tests/css-css-same-element/rules.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://namespaces.plone.org/diazo"
+       xmlns:css="http://namespaces.plone.org/diazo/css">
+
+    <rules css:if-content=".front-page">
+        <replace css:content=".placeholder">
+            <include css:content=".actual-content"/>
+        </replace>
+        <drop css:content=".wrapper" />
+    </rules>
+
+    <rules css:if-content=".community">
+        <replace css:content=".placeholder">
+            <include css:content=".actual-content"/>
+        </replace>
+        <drop css:content=".wrapper" />
+    </rules>
+
+   <replace css:content=".content" css:theme=".content"/>
+
+</rules>

--- a/lib/diazo/tests/css-css-same-element/theme.html
+++ b/lib/diazo/tests/css-css-same-element/theme.html
@@ -1,0 +1,3 @@
+<div class="content">
+    <div >Content</div>
+</div>

--- a/lib/diazo/tests/css-xpath-same-element/content.html
+++ b/lib/diazo/tests/css-xpath-same-element/content.html
@@ -1,0 +1,10 @@
+<html>
+  <body class="front-page">
+    <div class="content">
+      <p class="placeholder"><!-- nothing --></p>
+      <div class="wrapper">
+        <p class="actual-content">my text here</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/css-xpath-same-element/output.html
+++ b/lib/diazo/tests/css-xpath-same-element/output.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div class="content">
+      <p class="actual-content">my text here</p>
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/css-xpath-same-element/rules.xml
+++ b/lib/diazo/tests/css-xpath-same-element/rules.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://namespaces.plone.org/diazo"
+       xmlns:css="http://namespaces.plone.org/diazo/css">
+
+    <rules css:if-content=".front-page">
+        <replace content="//*[contains(@class, 'placeholder')]">
+            <include content="//*[contains(@class, 'actual-content')]"/>
+        </replace>
+        <drop content="//*[contains(@class, 'wrapper')]" />
+    </rules>
+
+    <rules css:if-content=".community">
+        <replace css:content=".placeholder">
+            <include css:content=".actual-content"/>
+        </replace>
+        <drop css:content=".wrapper" />
+    </rules>
+
+   <replace css:content=".content" css:theme=".content"/>
+
+</rules>

--- a/lib/diazo/tests/css-xpath-same-element/theme.html
+++ b/lib/diazo/tests/css-xpath-same-element/theme.html
@@ -1,0 +1,3 @@
+<div class="content">
+    <div >Content</div>
+</div>

--- a/lib/diazo/tests/xpath-xpath-same-element/content.html
+++ b/lib/diazo/tests/xpath-xpath-same-element/content.html
@@ -1,0 +1,10 @@
+<html>
+  <body class="front-page">
+    <div class="content">
+      <p class="placeholder"><!-- nothing --></p>
+      <div class="wrapper">
+        <p class="actual-content">my text here</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/xpath-xpath-same-element/output.html
+++ b/lib/diazo/tests/xpath-xpath-same-element/output.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <div class="content">
+      <p class="actual-content">my text here</p>
+    </div>
+  </body>
+</html>

--- a/lib/diazo/tests/xpath-xpath-same-element/rules.xml
+++ b/lib/diazo/tests/xpath-xpath-same-element/rules.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://namespaces.plone.org/diazo"
+       xmlns:css="http://namespaces.plone.org/diazo/css">
+
+    <rules css:if-content=".front-page">
+        <replace content="//*[contains(@class, 'placeholder')]">
+            <include content="//*[contains(@class, 'actual-content')]"/>
+        </replace>
+        <drop content="//*[contains(@class, 'wrapper')]" />
+    </rules>
+
+    <rules css:if-content=".community">
+        <replace content="//*[contains(@class, 'placeholder')]">
+            <include content="//*[contains(@class, 'actual-content')]"/>
+        </replace>
+        <drop content="//*[contains(@class, 'wrapper')]" />
+    </rules>
+
+   <replace css:content=".content" css:theme=".content"/>
+
+</rules>

--- a/lib/diazo/tests/xpath-xpath-same-element/theme.html
+++ b/lib/diazo/tests/xpath-xpath-same-element/theme.html
@@ -1,0 +1,3 @@
+<div class="content">
+    <div >Content</div>
+</div>


### PR DESCRIPTION
These tests showcase an error we noticed at www.freitag.de:

If you have the very same rules,
but one written with CSS selectors and the other with xpath selectors,
but only one should be applied at a time (there's a conditional guard for each of them)
the conditional is ignored and both rules are applied.

This does not happen if both rules are done in either CSS or xpath as can be seen on the ``css-css-same-element`` and ``xpath-xpath-same-element`` tests.

**The puzzling thing is that *depending on the inner rules* a conditional is applied or not.**