### PR TITLE
Prevent AttributeError when running the doctests of plone.app.testing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Add compatibility for plone.app.testing for Python 3.
+  [icemac]
 
 
 1.2.8 (2017-08-28)

--- a/lib/diazo/utils.py
+++ b/lib/diazo/utils.py
@@ -12,7 +12,11 @@ import sys
 
 
 if PY3:
-    stdout = sys.stdout.buffer
+    try:
+        stdout = sys.stdout.buffer
+    except AttributeError:
+        # This can happen in (doc-)tests e. g. in plone.app.testing:
+        stdout = None
 else:
     stdout = sys.stdout
 


### PR DESCRIPTION
Actual error:

`AttributeError: '_SpoofOut' object has no attribute 'buffer'`