### PR TITLE
Travis: test on 3.8, not 3.8-dev. Drop 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
           env: TOXENV=lint-py3
         - python: "2.7"
           env: TOXENV=py27
-        - python: "3.4"
-          env: TOXENV=py34
         - python: "3.5"
           env: TOXENV=py35
         - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
           env: TOXENV=py36
         - python: "3.7"
           env: TOXENV=py37
-        - python: "3.8-dev"
+        - python: "3.8"
           env: TOXENV=py38
 
 install:

--- a/constraints.txt
+++ b/constraints.txt
@@ -65,7 +65,7 @@ idna==2.6
 imagesize==0.7.1
 Jinja2==2.9.6
 lxml==3.8.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mccabe==0.6.1
 mock==2.0.0
 pbr==3.1.1

--- a/news/78.feature
+++ b/news/78.feature
@@ -1,0 +1,2 @@
+Drop support for Python 3.4.  No code changes.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@
 [tox]
 envlist =
     py27,
-    py34,
     py35,
     py36,
     py37,
@@ -13,7 +12,7 @@ envlist =
     docs,
     lint-py2,
     lint-py3,
-    coverage-report,
+    coverage-report
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
No need to test on Jenkins, but Travis should succeed.

I initially only changed 3.8-dev to 3.8, but then Travis failed on 3.4, so I dropped it.

But the `lint-py3` tox env fails on Travis (passes locally), so it's not done yet... Okay, known error in `MarkupSafe` 1.0, fixed by upgrading it to 1.1.1 in `constraints.txt`.

Most tox envs fail locally for me, likely due to a newer setuptools, but Travis is happy.