### PR TITLE
Fix coverage-report when running tox in parallel mode.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,14 @@ whitelist_externals =
 [testenv:coverage-report]
 skip_install = true
 
+depends =
+    py27,
+    py35,
+    py36,
+    py37,
+    py38,
+    py39,
+
 deps =
     -cconstraints.txt
     coverage


### PR DESCRIPTION
coverage-report needs to run after all the other tests, otherwise it has no data to combine:

```
$ tox -p auto
...
coverage-report create: /Users/maurits/community/plone-coredev/py3/src/diazo/.tox/coverage-report
coverage-report installdeps: -cconstraints.txt, coverage
coverage-report installed: coverage==5.5
coverage-report run-test-pre: PYTHONHASHSEED='1123133704'
coverage-report run-test: commands[0] | coverage erase
coverage-report run-test: commands[1] | coverage combine
No data to combine
ERROR: InvocationError for command /Users/maurits/community/plone-coredev/py3/src/diazo/.tox/coverage-report/bin/coverage combine (exited with code 1)
...
✖ FAIL coverage-report in 4.781 seconds
✔ OK isort in 5.089 seconds
✔ OK lint in 28.259 seconds
✔ OK py38 in 28.424 seconds
✔ OK py37 in 28.729 seconds
✔ OK docs in 28.768 seconds
✔ OK py39 in 30.278 seconds
✔ OK py36 in 30.898 seconds
✔ OK py27 in 31.464 seconds
✔ OK py35 in 34.338 seconds
```

After this commit, it works.  Done with tox4 for good measure:

```
$ tox4 -p auto
isort: OK ✔ in 3.74 seconds
docs: OK ✔ in 31.41 seconds
py35: OK ✔ in 32.73 seconds
py38: OK ✔ in 33.13 seconds
lint: OK ✔ in 33.19 seconds
py39: OK ✔ in 33.22 seconds
py37: OK ✔ in 33.26 seconds
py36: OK ✔ in 34.24 seconds
py27: OK ✔ in 35.04 seconds
  py27: OK (35.04=setup[26.63]+cmd[0.01,1.21,0.00,7.20] seconds)
  py35: OK (32.73=setup[25.86]+cmd[0.01,0.65,0.01,6.20] seconds)
  py36: OK (34.24=setup[26.63]+cmd[0.01,1.62,0.00,5.97] seconds)
  py37: OK (33.26=setup[26.50]+cmd[0.01,0.78,0.00,5.97] seconds)
  py38: OK (33.13=setup[26.23]+cmd[0.01,0.52,0.00,6.36] seconds)
  py39: OK (33.22=setup[26.25]+cmd[0.02,0.88,0.00,6.07] seconds)
  docs: OK (31.41=setup[26.24]+cmd[0.01,0.75,0.00,4.40] seconds)
  isort: OK (3.74=setup[2.93]+cmd[0.35,0.46] seconds)
  lint: OK (33.19=setup[26.22]+cmd[0.01,0.64,0.00,6.31] seconds)
  coverage-report: OK (3.53=setup[1.75]+cmd[0.54,0.16,0.27,0.44,0.37] seconds)
  congratulations :) (38.61 seconds)
```

BTW, current coverage is at 73 percent.

![Screenshot 2021-03-09 at 09 34 12](https://user-images.githubusercontent.com/210587/110441983-aaa2cb00-80ba-11eb-9061-bd4bb86f23bb.png)
