### PR TITLE
Remove FormEncode test dependency.

### DIFF
--- a/news/83.bugfix
+++ b/news/83.bugfix
@@ -1,0 +1,2 @@
+Remove FormEncode test dependency.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ extras_require = {
         'WebOb',
     ],
     'test': [
-        'formencode',
         'repoze.xmliter',
         'WebOb',
     ],


### PR DESCRIPTION
Instead copy its xml_compare and text_compare functions.
Taken from version 2.0.1.

I ran into a problem compiling the 1.3.1 egg, so I looked into who was using FormEncode in Plone,
and it turned out to only be a test dependency of Diazo.