### PR TITLE
Fix meta workflow

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -2,15 +2,9 @@
 # https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
+
 on:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
   workflow_dispatch:
 
 ##

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -20,10 +20,10 @@ on:
 jobs:
   qa:
     uses: plone/meta/.github/workflows/qa.yml@2.x
-  test:
-    uses: plone/meta/.github/workflows/test.yml@2.x
   coverage:
     uses: plone/meta/.github/workflows/coverage.yml@2.x
+  dependencies:
+    uses: plone/meta/.github/workflows/dependencies.yml@2.x
   release_ready:
     uses: plone/meta/.github/workflows/release_ready.yml@2.x
   circular:

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -5,6 +5,7 @@ name: Tests
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.meta.toml
+++ b/.meta.toml
@@ -5,15 +5,6 @@
 template = "default"
 commit-id = "2.6.1.dev0"
 
-[github]
-jobs = [
-    "qa",
-    "test",
-    "coverage",
-    "release_ready",
-    "circular",
-    ]
-
 [pre_commit]
 zpretty_extra_lines = """
         # Various test failures when we change xml and html.

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.5.1"
+commit-id = "2.6.1.dev0"
 
 [github]
 jobs = [

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,2 +1,2 @@
-Update configuration files.
+Update action workflows and other configuration files.
 [plone devs]


### PR DESCRIPTION
Run the standard jobs:

* No longer add the `test` job, as we have the test matrix workflow for that.
* No longer skip the `dependencies` job, as it seems to run fine.

See https://github.com/plone/diazo/pull/96#issuecomment-4073830516